### PR TITLE
Add duty fees management functionality

### DIFF
--- a/backend/src/controllers/duty-fees-controller.ts
+++ b/backend/src/controllers/duty-fees-controller.ts
@@ -1,0 +1,189 @@
+import { Request, Response, NextFunction } from 'express';
+import { DutyFeesService } from '../services/duty-fees-service';
+import { createDutyFeeSchema, updateDutyFeeSchema, dutyFeeParamsSchema, packageParamsSchema } from '../validation/duty-fee-schemas';
+import { ApiResponse } from '../utils/response';
+import { AuditLogsService } from '../services/audit-logs-service';
+
+interface AuthRequest extends Request {
+  companyId?: string;
+  userId?: string;
+  role?: string;
+}
+
+export class DutyFeesController {
+  private service: DutyFeesService;
+  private auditLogsService: AuditLogsService;
+
+  constructor() {
+    this.service = new DutyFeesService();
+    this.auditLogsService = new AuditLogsService();
+  }
+
+  /**
+   * Get all duty fees for a company
+   */
+  getAllDutyFees = async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const companyId = req.companyId as string;
+      const dutyFees = await this.service.getAllDutyFees(companyId);
+      return ApiResponse.success(res, dutyFees);
+    } catch (error) {
+      return next(error);
+    }
+  };
+
+  /**
+   * Get duty fees for a specific package
+   */
+  getDutyFeesByPackageId = async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const companyId = req.companyId as string;
+      const { packageId } = packageParamsSchema.parse(req.params);
+      
+      const dutyFees = await this.service.getDutyFeesByPackageId(packageId, companyId);
+      return ApiResponse.success(res, dutyFees);
+    } catch (error) {
+      return next(error);
+    }
+  };
+
+  /**
+   * Get a specific duty fee by ID
+   */
+  getDutyFeeById = async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const companyId = req.companyId as string;
+      const { id } = dutyFeeParamsSchema.parse(req.params);
+      
+      const dutyFee = await this.service.getDutyFeeById(id, companyId);
+      return ApiResponse.success(res, dutyFee);
+    } catch (error) {
+      return next(error);
+    }
+  };
+
+  /**
+   * Create a new duty fee
+   */
+  createDutyFee = async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const companyId = req.companyId as string;
+      const userId = req.userId as string;
+      
+      const validatedData = createDutyFeeSchema.parse(req.body);
+      const dutyFee = await this.service.createDutyFee(validatedData, companyId);
+
+      // Log the action
+      await this.auditLogsService.createLog({
+        userId,
+        companyId,
+        action: 'CREATE_DUTY_FEE',
+        entityType: 'duty_fee',
+        entityId: dutyFee.id,
+        details: {
+          packageId: dutyFee.packageId,
+          feeType: dutyFee.feeType,
+          amount: dutyFee.amount,
+          currency: dutyFee.currency,
+        },
+      });
+
+      return ApiResponse.success(res, dutyFee, 'Duty fee created successfully', 201);
+    } catch (error) {
+      return next(error);
+    }
+  };
+
+  /**
+   * Update a duty fee
+   */
+  updateDutyFee = async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const companyId = req.companyId as string;
+      const userId = req.userId as string;
+      
+      const { id } = dutyFeeParamsSchema.parse(req.params);
+      const validatedData = updateDutyFeeSchema.parse(req.body);
+      
+      const updatedDutyFee = await this.service.updateDutyFee(id, validatedData, companyId);
+
+      // Log the action
+      await this.auditLogsService.createLog({
+        userId,
+        companyId,
+        action: 'UPDATE_DUTY_FEE',
+        entityType: 'duty_fee',
+        entityId: id,
+        details: {
+          changes: validatedData,
+        },
+      });
+
+      return ApiResponse.success(res, updatedDutyFee);
+    } catch (error) {
+      return next(error);
+    }
+  };
+
+  /**
+   * Delete a duty fee
+   */
+  deleteDutyFee = async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const companyId = req.companyId as string;
+      const userId = req.userId as string;
+      
+      const { id } = dutyFeeParamsSchema.parse(req.params);
+      await this.service.deleteDutyFee(id, companyId);
+
+      // Log the action
+      await this.auditLogsService.createLog({
+        userId,
+        companyId,
+        action: 'DELETE_DUTY_FEE',
+        entityType: 'duty_fee',
+        entityId: id,
+        details: {},
+      });
+
+      return ApiResponse.success(res, { message: 'Duty fee deleted successfully' });
+    } catch (error) {
+      return next(error);
+    }
+  };
+
+  /**
+   * Get duty fees grouped by currency for a package
+   */
+  getPackageFeesGroupedByCurrency = async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const companyId = req.companyId as string;
+      const { packageId } = packageParamsSchema.parse(req.params);
+      
+      const groupedFees = await this.service.getPackageFeesGroupedByCurrency(packageId, companyId);
+      return ApiResponse.success(res, groupedFees);
+    } catch (error) {
+      return next(error);
+    }
+  };
+
+  /**
+   * Get total duty fees for a package in a specific currency
+   */
+  getPackageFeeTotal = async (req: AuthRequest, res: Response, next: NextFunction) => {
+    try {
+      const companyId = req.companyId as string;
+      const { packageId } = packageParamsSchema.parse(req.params);
+      const currency = req.query.currency as 'USD' | 'JMD' || 'USD';
+      
+      if (!['USD', 'JMD'].includes(currency)) {
+        return ApiResponse.error(res, 'Invalid currency. Must be USD or JMD', 400);
+      }
+      
+      const total = await this.service.getPackageFeeTotal(packageId, currency, companyId);
+      return ApiResponse.success(res, { total, currency });
+    } catch (error) {
+      return next(error);
+    }
+  };
+}

--- a/backend/src/db/migrations/0025_aspiring_cannonball.sql
+++ b/backend/src/db/migrations/0025_aspiring_cannonball.sql
@@ -1,0 +1,36 @@
+DO $$ BEGIN
+ CREATE TYPE "currency" AS ENUM('USD', 'JMD');
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ CREATE TYPE "duty_fee_type" AS ENUM('Electronics', 'Clothing & Footwear', 'Food & Grocery', 'Household Appliances', 'Furniture', 'Construction Materials', 'Tools & Machinery', 'Cosmetics & Personal', 'Medical Equipment', 'Agricultural Products', 'Pet Supplies', 'Books & Education', 'Mobile Accessories', 'ANIMALS', 'SOLAR EQUIPMENT', 'WRIST WATCHES', 'Other');
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "duty_fees" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"company_id" uuid NOT NULL,
+	"package_id" uuid NOT NULL,
+	"fee_type" "duty_fee_type" NOT NULL,
+	"custom_fee_type" text,
+	"amount" numeric(10, 2) NOT NULL,
+	"currency" "currency" DEFAULT 'USD' NOT NULL,
+	"description" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "duty_fees" ADD CONSTRAINT "duty_fees_company_id_companies_id_fk" FOREIGN KEY ("company_id") REFERENCES "companies"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "duty_fees" ADD CONSTRAINT "duty_fees_package_id_packages_id_fk" FOREIGN KEY ("package_id") REFERENCES "packages"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/backend/src/db/migrations/0026_elite_stardust.sql
+++ b/backend/src/db/migrations/0026_elite_stardust.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "invoice_item_type" ADD VALUE 'duty';

--- a/backend/src/db/migrations/meta/0025_snapshot.json
+++ b/backend/src/db/migrations/meta/0025_snapshot.json
@@ -1,0 +1,1683 @@
+{
+  "version": "5",
+  "dialect": "pg",
+  "id": "a961bbd3-5fb1-499f-aeb1-789c2da6d192",
+  "prevId": "068d28e0-bd62-432d-9fc5-846afca1be3a",
+  "tables": {
+    "audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_logs_company_id_companies_id_fk": {
+          "name": "audit_logs_company_id_companies_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "companies": {
+      "name": "companies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subdomain": {
+          "name": "subdomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "images": {
+          "name": "images",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_info": {
+          "name": "shipping_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locations": {
+          "name": "locations",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bank_info": {
+          "name": "bank_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "companies_subdomain_unique": {
+          "name": "companies_subdomain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "subdomain"
+          ]
+        },
+        "companies_email_unique": {
+          "name": "companies_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    },
+    "company_assets": {
+      "name": "company_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "asset_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "image_data": {
+          "name": "image_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "company_assets_company_id_companies_id_fk": {
+          "name": "company_assets_company_id_companies_id_fk",
+          "tableFrom": "company_assets",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "company_invitations": {
+      "name": "company_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "invitation_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "company_invitations_token_unique": {
+          "name": "company_invitations_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      }
+    },
+    "company_settings": {
+      "name": "company_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_prefix": {
+          "name": "internal_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SPX'"
+        },
+        "notification_settings": {
+          "name": "notification_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "theme_settings": {
+          "name": "theme_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "payment_settings": {
+          "name": "payment_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "integration_settings": {
+          "name": "integration_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "exchange_rate_settings": {
+          "name": "exchange_rate_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"baseCurrency\":\"USD\",\"targetCurrency\":\"JMD\",\"exchangeRate\":158.5,\"lastUpdated\":null,\"autoUpdate\":false}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "company_settings_company_id_companies_id_fk": {
+          "name": "company_settings_company_id_companies_id_fk",
+          "tableFrom": "company_settings",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "company_settings_company_id_unique": {
+          "name": "company_settings_company_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "company_id"
+          ]
+        }
+      }
+    },
+    "duty_fees": {
+      "name": "duty_fees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_type": {
+          "name": "fee_type",
+          "type": "duty_fee_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_fee_type": {
+          "name": "custom_fee_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "duty_fees_company_id_companies_id_fk": {
+          "name": "duty_fees_company_id_companies_id_fk",
+          "tableFrom": "duty_fees",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "duty_fees_package_id_packages_id_fk": {
+          "name": "duty_fees_package_id_packages_id_fk",
+          "tableFrom": "duty_fees",
+          "tableTo": "packages",
+          "columnsFrom": [
+            "package_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "fees": {
+      "name": "fees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_type": {
+          "name": "fee_type",
+          "type": "fee_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calculation_method": {
+          "name": "calculation_method",
+          "type": "calculation_method",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "applies_to": {
+          "name": "applies_to",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fees_company_id_companies_id_fk": {
+          "name": "fees_company_id_companies_id_fk",
+          "tableFrom": "fees",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "invoice_items": {
+      "name": "invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_total": {
+          "name": "line_total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "invoice_item_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoice_items_company_id_companies_id_fk": {
+          "name": "invoice_items_company_id_companies_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_items_package_id_packages_id_fk": {
+          "name": "invoice_items_package_id_packages_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "packages",
+          "columnsFrom": [
+            "package_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "issue_date": {
+          "name": "issue_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "tax_amount": {
+          "name": "tax_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fee_breakdown": {
+          "name": "fee_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoices_company_id_companies_id_fk": {
+          "name": "invoices_company_id_companies_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoices_user_id_users_id_fk": {
+          "name": "invoices_user_id_users_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoices_invoice_number_unique": {
+          "name": "invoices_invoice_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invoice_number"
+          ]
+        }
+      }
+    },
+    "packages": {
+      "name": "packages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pref_id": {
+          "name": "pref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracking_number": {
+          "name": "tracking_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "package_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'received'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "declared_value": {
+          "name": "declared_value",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_info": {
+          "name": "sender_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_date": {
+          "name": "received_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_date": {
+          "name": "processing_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photos": {
+          "name": "photos",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "packages_company_id_companies_id_fk": {
+          "name": "packages_company_id_companies_id_fk",
+          "tableFrom": "packages",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "packages_user_id_users_id_fk": {
+          "name": "packages_user_id_users_id_fk",
+          "tableFrom": "packages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "packages_tracking_number_unique": {
+          "name": "packages_tracking_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tracking_number"
+          ]
+        }
+      }
+    },
+    "payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "payment_method",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "payment_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_date": {
+          "name": "payment_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "payments_company_id_companies_id_fk": {
+          "name": "payments_company_id_companies_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payments_invoice_id_invoices_id_fk": {
+          "name": "payments_invoice_id_invoices_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payments_user_id_users_id_fk": {
+          "name": "payments_user_id_users_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "pre_alerts": {
+      "name": "pre_alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tracking_number": {
+          "name": "tracking_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "courier": {
+          "name": "courier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_weight": {
+          "name": "estimated_weight",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_arrival": {
+          "name": "estimated_arrival",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "pre_alert_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "documents": {
+          "name": "documents",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pre_alerts_company_id_companies_id_fk": {
+          "name": "pre_alerts_company_id_companies_id_fk",
+          "tableFrom": "pre_alerts",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pre_alerts_user_id_users_id_fk": {
+          "name": "pre_alerts_user_id_users_id_fk",
+          "tableFrom": "pre_alerts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pre_alerts_package_id_packages_id_fk": {
+          "name": "pre_alerts_package_id_packages_id_fk",
+          "tableFrom": "pre_alerts",
+          "tableTo": "packages",
+          "columnsFrom": [
+            "package_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pref_id": {
+          "name": "pref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trn": {
+          "name": "trn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'customer'"
+        },
+        "auth0_id": {
+          "name": "auth0_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verification_token": {
+          "name": "verification_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_token_expires": {
+          "name": "verification_token_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_preferences": {
+          "name": "notification_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"email\":true,\"sms\":false,\"push\":false,\"packageUpdates\":{\"email\":true,\"sms\":false,\"push\":false},\"billingUpdates\":{\"email\":true,\"sms\":false,\"push\":false},\"marketingUpdates\":{\"email\":false,\"sms\":false,\"push\":false},\"pickupLocationId\":null}'::jsonb"
+        },
+        "reset_token": {
+          "name": "reset_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_token_expires": {
+          "name": "reset_token_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_company_id_companies_id_fk": {
+          "name": "users_company_id_companies_id_fk",
+          "tableFrom": "users",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_internal_id_unique": {
+          "name": "users_internal_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "internal_id"
+          ]
+        },
+        "users_pref_id_unique": {
+          "name": "users_pref_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pref_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "asset_type": {
+      "name": "asset_type",
+      "values": {
+        "logo": "logo",
+        "banner": "banner",
+        "favicon": "favicon",
+        "small_logo": "small_logo"
+      }
+    },
+    "invitation_status": {
+      "name": "invitation_status",
+      "values": {
+        "pending": "pending",
+        "accepted": "accepted",
+        "expired": "expired",
+        "cancelled": "cancelled"
+      }
+    },
+    "currency": {
+      "name": "currency",
+      "values": {
+        "USD": "USD",
+        "JMD": "JMD"
+      }
+    },
+    "duty_fee_type": {
+      "name": "duty_fee_type",
+      "values": {
+        "Electronics": "Electronics",
+        "Clothing & Footwear": "Clothing & Footwear",
+        "Food & Grocery": "Food & Grocery",
+        "Household Appliances": "Household Appliances",
+        "Furniture": "Furniture",
+        "Construction Materials": "Construction Materials",
+        "Tools & Machinery": "Tools & Machinery",
+        "Cosmetics & Personal": "Cosmetics & Personal",
+        "Medical Equipment": "Medical Equipment",
+        "Agricultural Products": "Agricultural Products",
+        "Pet Supplies": "Pet Supplies",
+        "Books & Education": "Books & Education",
+        "Mobile Accessories": "Mobile Accessories",
+        "ANIMALS": "ANIMALS",
+        "SOLAR EQUIPMENT": "SOLAR EQUIPMENT",
+        "WRIST WATCHES": "WRIST WATCHES",
+        "Other": "Other"
+      }
+    },
+    "calculation_method": {
+      "name": "calculation_method",
+      "values": {
+        "fixed": "fixed",
+        "percentage": "percentage",
+        "per_weight": "per_weight",
+        "per_item": "per_item",
+        "dimensional": "dimensional",
+        "tiered": "tiered",
+        "threshold": "threshold",
+        "timed": "timed"
+      }
+    },
+    "fee_type": {
+      "name": "fee_type",
+      "values": {
+        "tax": "tax",
+        "service": "service",
+        "shipping": "shipping",
+        "handling": "handling",
+        "customs": "customs",
+        "other": "other"
+      }
+    },
+    "invoice_item_type": {
+      "name": "invoice_item_type",
+      "values": {
+        "shipping": "shipping",
+        "handling": "handling",
+        "customs": "customs",
+        "tax": "tax",
+        "other": "other"
+      }
+    },
+    "invoice_status": {
+      "name": "invoice_status",
+      "values": {
+        "draft": "draft",
+        "issued": "issued",
+        "paid": "paid",
+        "cancelled": "cancelled",
+        "overdue": "overdue"
+      }
+    },
+    "package_status": {
+      "name": "package_status",
+      "values": {
+        "in_transit": "in_transit",
+        "pre_alert": "pre_alert",
+        "received": "received",
+        "processed": "processed",
+        "ready_for_pickup": "ready_for_pickup",
+        "delivered": "delivered",
+        "returned": "returned"
+      }
+    },
+    "payment_method": {
+      "name": "payment_method",
+      "values": {
+        "credit_card": "credit_card",
+        "bank_transfer": "bank_transfer",
+        "cash": "cash",
+        "check": "check",
+        "online": "online"
+      }
+    },
+    "payment_status": {
+      "name": "payment_status",
+      "values": {
+        "pending": "pending",
+        "completed": "completed",
+        "failed": "failed",
+        "refunded": "refunded"
+      }
+    },
+    "pre_alert_status": {
+      "name": "pre_alert_status",
+      "values": {
+        "pending": "pending",
+        "matched": "matched",
+        "cancelled": "cancelled"
+      }
+    },
+    "user_role": {
+      "name": "user_role",
+      "values": {
+        "customer": "customer",
+        "admin_l1": "admin_l1",
+        "admin_l2": "admin_l2",
+        "super_admin": "super_admin"
+      }
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/backend/src/db/migrations/meta/0026_snapshot.json
+++ b/backend/src/db/migrations/meta/0026_snapshot.json
@@ -1,0 +1,1684 @@
+{
+  "version": "5",
+  "dialect": "pg",
+  "id": "cdf16acf-f06a-49e8-9ff7-ccd902ff339d",
+  "prevId": "a961bbd3-5fb1-499f-aeb1-789c2da6d192",
+  "tables": {
+    "audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_logs_company_id_companies_id_fk": {
+          "name": "audit_logs_company_id_companies_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "companies": {
+      "name": "companies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subdomain": {
+          "name": "subdomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "images": {
+          "name": "images",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_info": {
+          "name": "shipping_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locations": {
+          "name": "locations",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bank_info": {
+          "name": "bank_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "companies_subdomain_unique": {
+          "name": "companies_subdomain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "subdomain"
+          ]
+        },
+        "companies_email_unique": {
+          "name": "companies_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    },
+    "company_assets": {
+      "name": "company_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "asset_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "image_data": {
+          "name": "image_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "company_assets_company_id_companies_id_fk": {
+          "name": "company_assets_company_id_companies_id_fk",
+          "tableFrom": "company_assets",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "company_invitations": {
+      "name": "company_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "invitation_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "company_invitations_token_unique": {
+          "name": "company_invitations_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      }
+    },
+    "company_settings": {
+      "name": "company_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_prefix": {
+          "name": "internal_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SPX'"
+        },
+        "notification_settings": {
+          "name": "notification_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "theme_settings": {
+          "name": "theme_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "payment_settings": {
+          "name": "payment_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "integration_settings": {
+          "name": "integration_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "exchange_rate_settings": {
+          "name": "exchange_rate_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"baseCurrency\":\"USD\",\"targetCurrency\":\"JMD\",\"exchangeRate\":158.5,\"lastUpdated\":null,\"autoUpdate\":false}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "company_settings_company_id_companies_id_fk": {
+          "name": "company_settings_company_id_companies_id_fk",
+          "tableFrom": "company_settings",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "company_settings_company_id_unique": {
+          "name": "company_settings_company_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "company_id"
+          ]
+        }
+      }
+    },
+    "duty_fees": {
+      "name": "duty_fees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_type": {
+          "name": "fee_type",
+          "type": "duty_fee_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_fee_type": {
+          "name": "custom_fee_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "duty_fees_company_id_companies_id_fk": {
+          "name": "duty_fees_company_id_companies_id_fk",
+          "tableFrom": "duty_fees",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "duty_fees_package_id_packages_id_fk": {
+          "name": "duty_fees_package_id_packages_id_fk",
+          "tableFrom": "duty_fees",
+          "tableTo": "packages",
+          "columnsFrom": [
+            "package_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "fees": {
+      "name": "fees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_type": {
+          "name": "fee_type",
+          "type": "fee_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calculation_method": {
+          "name": "calculation_method",
+          "type": "calculation_method",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "applies_to": {
+          "name": "applies_to",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fees_company_id_companies_id_fk": {
+          "name": "fees_company_id_companies_id_fk",
+          "tableFrom": "fees",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "invoice_items": {
+      "name": "invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_total": {
+          "name": "line_total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "invoice_item_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoice_items_company_id_companies_id_fk": {
+          "name": "invoice_items_company_id_companies_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_items_package_id_packages_id_fk": {
+          "name": "invoice_items_package_id_packages_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "packages",
+          "columnsFrom": [
+            "package_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "issue_date": {
+          "name": "issue_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "tax_amount": {
+          "name": "tax_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fee_breakdown": {
+          "name": "fee_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoices_company_id_companies_id_fk": {
+          "name": "invoices_company_id_companies_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoices_user_id_users_id_fk": {
+          "name": "invoices_user_id_users_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoices_invoice_number_unique": {
+          "name": "invoices_invoice_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invoice_number"
+          ]
+        }
+      }
+    },
+    "packages": {
+      "name": "packages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pref_id": {
+          "name": "pref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracking_number": {
+          "name": "tracking_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "package_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'received'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "declared_value": {
+          "name": "declared_value",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_info": {
+          "name": "sender_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_date": {
+          "name": "received_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_date": {
+          "name": "processing_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photos": {
+          "name": "photos",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "packages_company_id_companies_id_fk": {
+          "name": "packages_company_id_companies_id_fk",
+          "tableFrom": "packages",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "packages_user_id_users_id_fk": {
+          "name": "packages_user_id_users_id_fk",
+          "tableFrom": "packages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "packages_tracking_number_unique": {
+          "name": "packages_tracking_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tracking_number"
+          ]
+        }
+      }
+    },
+    "payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "payment_method",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "payment_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_date": {
+          "name": "payment_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "payments_company_id_companies_id_fk": {
+          "name": "payments_company_id_companies_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payments_invoice_id_invoices_id_fk": {
+          "name": "payments_invoice_id_invoices_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payments_user_id_users_id_fk": {
+          "name": "payments_user_id_users_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "pre_alerts": {
+      "name": "pre_alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tracking_number": {
+          "name": "tracking_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "courier": {
+          "name": "courier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_weight": {
+          "name": "estimated_weight",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_arrival": {
+          "name": "estimated_arrival",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "pre_alert_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "documents": {
+          "name": "documents",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pre_alerts_company_id_companies_id_fk": {
+          "name": "pre_alerts_company_id_companies_id_fk",
+          "tableFrom": "pre_alerts",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pre_alerts_user_id_users_id_fk": {
+          "name": "pre_alerts_user_id_users_id_fk",
+          "tableFrom": "pre_alerts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pre_alerts_package_id_packages_id_fk": {
+          "name": "pre_alerts_package_id_packages_id_fk",
+          "tableFrom": "pre_alerts",
+          "tableTo": "packages",
+          "columnsFrom": [
+            "package_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pref_id": {
+          "name": "pref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trn": {
+          "name": "trn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'customer'"
+        },
+        "auth0_id": {
+          "name": "auth0_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verification_token": {
+          "name": "verification_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_token_expires": {
+          "name": "verification_token_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_preferences": {
+          "name": "notification_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"email\":true,\"sms\":false,\"push\":false,\"packageUpdates\":{\"email\":true,\"sms\":false,\"push\":false},\"billingUpdates\":{\"email\":true,\"sms\":false,\"push\":false},\"marketingUpdates\":{\"email\":false,\"sms\":false,\"push\":false},\"pickupLocationId\":null}'::jsonb"
+        },
+        "reset_token": {
+          "name": "reset_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_token_expires": {
+          "name": "reset_token_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_company_id_companies_id_fk": {
+          "name": "users_company_id_companies_id_fk",
+          "tableFrom": "users",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_internal_id_unique": {
+          "name": "users_internal_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "internal_id"
+          ]
+        },
+        "users_pref_id_unique": {
+          "name": "users_pref_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pref_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "asset_type": {
+      "name": "asset_type",
+      "values": {
+        "logo": "logo",
+        "banner": "banner",
+        "favicon": "favicon",
+        "small_logo": "small_logo"
+      }
+    },
+    "invitation_status": {
+      "name": "invitation_status",
+      "values": {
+        "pending": "pending",
+        "accepted": "accepted",
+        "expired": "expired",
+        "cancelled": "cancelled"
+      }
+    },
+    "currency": {
+      "name": "currency",
+      "values": {
+        "USD": "USD",
+        "JMD": "JMD"
+      }
+    },
+    "duty_fee_type": {
+      "name": "duty_fee_type",
+      "values": {
+        "Electronics": "Electronics",
+        "Clothing & Footwear": "Clothing & Footwear",
+        "Food & Grocery": "Food & Grocery",
+        "Household Appliances": "Household Appliances",
+        "Furniture": "Furniture",
+        "Construction Materials": "Construction Materials",
+        "Tools & Machinery": "Tools & Machinery",
+        "Cosmetics & Personal": "Cosmetics & Personal",
+        "Medical Equipment": "Medical Equipment",
+        "Agricultural Products": "Agricultural Products",
+        "Pet Supplies": "Pet Supplies",
+        "Books & Education": "Books & Education",
+        "Mobile Accessories": "Mobile Accessories",
+        "ANIMALS": "ANIMALS",
+        "SOLAR EQUIPMENT": "SOLAR EQUIPMENT",
+        "WRIST WATCHES": "WRIST WATCHES",
+        "Other": "Other"
+      }
+    },
+    "calculation_method": {
+      "name": "calculation_method",
+      "values": {
+        "fixed": "fixed",
+        "percentage": "percentage",
+        "per_weight": "per_weight",
+        "per_item": "per_item",
+        "dimensional": "dimensional",
+        "tiered": "tiered",
+        "threshold": "threshold",
+        "timed": "timed"
+      }
+    },
+    "fee_type": {
+      "name": "fee_type",
+      "values": {
+        "tax": "tax",
+        "service": "service",
+        "shipping": "shipping",
+        "handling": "handling",
+        "customs": "customs",
+        "other": "other"
+      }
+    },
+    "invoice_item_type": {
+      "name": "invoice_item_type",
+      "values": {
+        "shipping": "shipping",
+        "handling": "handling",
+        "customs": "customs",
+        "tax": "tax",
+        "duty": "duty",
+        "other": "other"
+      }
+    },
+    "invoice_status": {
+      "name": "invoice_status",
+      "values": {
+        "draft": "draft",
+        "issued": "issued",
+        "paid": "paid",
+        "cancelled": "cancelled",
+        "overdue": "overdue"
+      }
+    },
+    "package_status": {
+      "name": "package_status",
+      "values": {
+        "in_transit": "in_transit",
+        "pre_alert": "pre_alert",
+        "received": "received",
+        "processed": "processed",
+        "ready_for_pickup": "ready_for_pickup",
+        "delivered": "delivered",
+        "returned": "returned"
+      }
+    },
+    "payment_method": {
+      "name": "payment_method",
+      "values": {
+        "credit_card": "credit_card",
+        "bank_transfer": "bank_transfer",
+        "cash": "cash",
+        "check": "check",
+        "online": "online"
+      }
+    },
+    "payment_status": {
+      "name": "payment_status",
+      "values": {
+        "pending": "pending",
+        "completed": "completed",
+        "failed": "failed",
+        "refunded": "refunded"
+      }
+    },
+    "pre_alert_status": {
+      "name": "pre_alert_status",
+      "values": {
+        "pending": "pending",
+        "matched": "matched",
+        "cancelled": "cancelled"
+      }
+    },
+    "user_role": {
+      "name": "user_role",
+      "values": {
+        "customer": "customer",
+        "admin_l1": "admin_l1",
+        "admin_l2": "admin_l2",
+        "super_admin": "super_admin"
+      }
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/backend/src/db/migrations/meta/_journal.json
+++ b/backend/src/db/migrations/meta/_journal.json
@@ -176,6 +176,20 @@
       "when": 1751760486436,
       "tag": "0024_illegal_wild_pack",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "5",
+      "when": 1753205169323,
+      "tag": "0025_aspiring_cannonball",
+      "breakpoints": true
+    },
+    {
+      "idx": 26,
+      "version": "5",
+      "when": 1753205802445,
+      "tag": "0026_elite_stardust",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/schema/duty-fees.ts
+++ b/backend/src/db/schema/duty-fees.ts
@@ -1,0 +1,42 @@
+import { pgTable, uuid, text, timestamp, decimal, pgEnum } from 'drizzle-orm/pg-core';
+import { companies } from './companies';
+import { packages } from './packages';
+
+export const dutyFeeTypeEnum = pgEnum('duty_fee_type', [
+  'Electronics',
+  'Clothing & Footwear', 
+  'Food & Grocery',
+  'Household Appliances',
+  'Furniture',
+  'Construction Materials',
+  'Tools & Machinery',
+  'Cosmetics & Personal',
+  'Medical Equipment',
+  'Agricultural Products',
+  'Pet Supplies',
+  'Books & Education',
+  'Mobile Accessories',
+  'ANIMALS',
+  'SOLAR EQUIPMENT',
+  'WRIST WATCHES',
+  'Other'
+]);
+
+export const currencyEnum = pgEnum('currency', ['USD', 'JMD']);
+
+export const dutyFees = pgTable('duty_fees', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  companyId: uuid('company_id').notNull().references(() => companies.id, {
+    onDelete: 'cascade',
+  }),
+  packageId: uuid('package_id').notNull().references(() => packages.id, {
+    onDelete: 'cascade',
+  }),
+  feeType: dutyFeeTypeEnum('fee_type').notNull(),
+  customFeeType: text('custom_fee_type'), // For user-defined fees when feeType is 'Other'
+  amount: decimal('amount', { precision: 10, scale: 2 }).notNull(),
+  currency: currencyEnum('currency').notNull().default('USD'),
+  description: text('description'),
+  createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+});

--- a/backend/src/db/schema/index.ts
+++ b/backend/src/db/schema/index.ts
@@ -8,6 +8,7 @@ import { invoiceItems } from './invoice-items';
 import { payments } from './payments';
 import { companySettings } from './company-settings';
 import { fees, feeTypeEnum, calculationMethodEnum } from './fees';
+import { dutyFees, dutyFeeTypeEnum, currencyEnum } from './duty-fees';
 import { auditLogs } from './audit-logs';
 import { companyInvitations } from './company-invitations';
 
@@ -24,6 +25,9 @@ export {
   fees,
   feeTypeEnum,
   calculationMethodEnum,
+  dutyFees,
+  dutyFeeTypeEnum,
+  currencyEnum,
   auditLogs,
   companyInvitations,
 }; 

--- a/backend/src/db/schema/invoice-items.ts
+++ b/backend/src/db/schema/invoice-items.ts
@@ -9,6 +9,7 @@ export const invoiceItemTypeEnum = pgEnum('invoice_item_type', [
   'handling',
   'customs',
   'tax',
+  'duty',
   'other',
 ]);
 

--- a/backend/src/repositories/duty-fees-repository.ts
+++ b/backend/src/repositories/duty-fees-repository.ts
@@ -1,0 +1,90 @@
+import { eq, and, sql } from 'drizzle-orm';
+import { BaseRepository } from './base-repository';
+import { dutyFees } from '../db/schema';
+
+export class DutyFeesRepository extends BaseRepository<typeof dutyFees> {
+  constructor() {
+    super(dutyFees);
+  }
+
+  /**
+   * Find all duty fees for a specific package
+   */
+  async findByPackageId(packageId: string, companyId: string) {
+    return this.db
+      .select()
+      .from(this.table)
+      .where(
+        and(
+          eq(this.table.packageId, packageId),
+          eq(this.table.companyId, companyId)
+        )
+      );
+  }
+
+  /**
+   * Find all duty fees for multiple packages
+   */
+  async findByPackageIds(packageIds: string[], companyId: string) {
+    if (packageIds.length === 0) return [];
+    
+    return this.db
+      .select()
+      .from(this.table)
+      .where(
+        and(
+          // Use SQL IN operator with package IDs
+          sql`${this.table.packageId} = ANY(${packageIds})`,
+          eq(this.table.companyId, companyId)
+        )
+      );
+  }
+
+  /**
+   * Get total duty fees amount for a package in a specific currency
+   */
+  async getTotalByPackageAndCurrency(packageId: string, currency: 'USD' | 'JMD', companyId: string): Promise<number> {
+    const result = await this.db
+      .select({
+        total: sql<number>`COALESCE(SUM(${this.table.amount}::numeric), 0)`
+      })
+      .from(this.table)
+      .where(
+        and(
+          eq(this.table.packageId, packageId),
+          eq(this.table.currency, currency),
+          eq(this.table.companyId, companyId)
+        )
+      );
+
+    return result[0]?.total || 0;
+  }
+
+  /**
+   * Get all duty fees for a package grouped by currency
+   */
+  async getPackageFeesGroupedByCurrency(packageId: string, companyId: string) {
+    const result = await this.db
+      .select({
+        currency: this.table.currency,
+        total: sql<number>`SUM(${this.table.amount}::numeric)`,
+        fees: sql<any[]>`json_agg(json_build_object(
+          'id', ${this.table.id},
+          'feeType', ${this.table.feeType},
+          'customFeeType', ${this.table.customFeeType},
+          'amount', ${this.table.amount},
+          'description', ${this.table.description}
+        ))`
+      })
+      .from(this.table)
+      .where(
+        and(
+          eq(this.table.packageId, packageId),
+          eq(this.table.companyId, companyId)
+        )
+      )
+      .groupBy(this.table.currency);
+
+    return result;
+  }
+}

--- a/backend/src/routes/duty-fees-routes.ts
+++ b/backend/src/routes/duty-fees-routes.ts
@@ -1,0 +1,35 @@
+import express from 'express';
+import { DutyFeesController } from '../controllers/duty-fees-controller';
+// import { checkJwt, checkRole } from '../middleware/auth';
+
+const router = express.Router({ mergeParams: true }); 
+const controller = new DutyFeesController();
+
+// Apply JWT authentication to all routes
+// router.use(checkJwt); NOTE: enable this and checkRole when we have login and auth implemented fully
+
+// Get all duty fees for the company (Admin L1+)
+router.get('/', /*checkRole(['admin_l1', 'admin_l2']),*/ controller.getAllDutyFees);
+
+// Get duty fees for a specific package (Admin L1+)
+router.get('/package/:packageId', /*checkRole(['admin_l1', 'admin_l2']),*/ controller.getDutyFeesByPackageId);
+
+// Get duty fees grouped by currency for a specific package (Admin L1+)
+router.get('/package/:packageId/grouped', /*checkRole(['admin_l1', 'admin_l2']),*/ controller.getPackageFeesGroupedByCurrency);
+
+// Get total duty fees for a specific package in a currency (Admin L1+)
+router.get('/package/:packageId/total', /*checkRole(['admin_l1', 'admin_l2']),*/ controller.getPackageFeeTotal);
+
+// Create a new duty fee (Admin L1+)
+router.post('/', /*checkRole(['admin_l1', 'admin_l2']),*/ controller.createDutyFee);
+
+// Get specific duty fee by ID (Admin L1+)
+router.get('/:id', /*checkRole(['admin_l1', 'admin_l2']),*/ controller.getDutyFeeById);
+
+// Update a duty fee (Admin L1+)
+router.put('/:id', /*checkRole(['admin_l1', 'admin_l2']),*/ controller.updateDutyFee);
+
+// Delete a duty fee (Admin L1+)
+router.delete('/:id', /*checkRole(['admin_l1', 'admin_l2']),*/ controller.deleteDutyFee);
+
+export { router as dutyFeesRoutes };

--- a/backend/src/routes/index.ts
+++ b/backend/src/routes/index.ts
@@ -14,6 +14,7 @@ import paymentsRoutes from './payments-routes';
 import billingRoutes from './billing-routes';
 import importRoutes from './import-routes';
 import autoImportRoutes from './auto-import-routes';
+import { dutyFeesRoutes } from './duty-fees-routes';
 import { extractCompanyId, checkJwt } from '../middleware/auth';
 import { CompanySettingsController } from '../controllers/company-settings-controller';
 import { CompanyAssetsController } from '../controllers/company-assets-controller';
@@ -96,6 +97,9 @@ protectedRoutes.use('/company-settings', companySettingsRoutes);
 
 // Fees routes - scoped to company
 protectedRoutes.use('/companies/:companyId/fees', feesRoutes);
+
+// Duty fees routes - scoped to company
+protectedRoutes.use('/companies/:companyId/duty-fees', dutyFeesRoutes);
 
 // Billing routes - scoped to company
 protectedRoutes.use('/companies/:companyId/billing', billingRoutes);

--- a/backend/src/services/duty-fees-service.ts
+++ b/backend/src/services/duty-fees-service.ts
@@ -1,0 +1,162 @@
+import { DutyFeesRepository } from '../repositories/duty-fees-repository';
+import { PackagesRepository } from '../repositories/packages-repository';
+import { AppError } from '../utils/app-error';
+import { CreateDutyFeeRequest, UpdateDutyFeeRequest, DutyFee } from '../types/duty-fee';
+
+export class DutyFeesService {
+  private dutyFeesRepository: DutyFeesRepository;
+  private packagesRepository: PackagesRepository;
+
+  constructor() {
+    this.dutyFeesRepository = new DutyFeesRepository();
+    this.packagesRepository = new PackagesRepository();
+  }
+
+  /**
+   * Get all duty fees for a company
+   */
+  async getAllDutyFees(companyId: string): Promise<DutyFee[]> {
+    return this.dutyFeesRepository.findAll(companyId);
+  }
+
+  /**
+   * Get duty fees for a specific package
+   */
+  async getDutyFeesByPackageId(packageId: string, companyId: string): Promise<DutyFee[]> {
+    // Verify package exists and belongs to company
+    const packageExists = await this.packagesRepository.findById(packageId, companyId);
+    if (!packageExists) {
+      throw new AppError('Package not found', 404);
+    }
+
+    const dutyFees = await this.dutyFeesRepository.findByPackageId(packageId, companyId);
+    return dutyFees as DutyFee[];
+  }
+
+  /**
+   * Get a specific duty fee by ID
+   */
+  async getDutyFeeById(id: string, companyId: string): Promise<DutyFee> {
+    const dutyFee = await this.dutyFeesRepository.findById(id, companyId);
+    if (!dutyFee) {
+      throw new AppError('Duty fee not found', 404);
+    }
+    return dutyFee as DutyFee;
+  }
+
+  /**
+   * Create a new duty fee
+   */
+  async createDutyFee(data: CreateDutyFeeRequest, companyId: string): Promise<DutyFee> {
+    // Verify package exists and belongs to company
+    const existingPackage = await this.packagesRepository.findById(data.packageId, companyId);
+    if (!existingPackage) {
+      throw new AppError('Package not found', 404);
+    }
+
+    // Check if package is in a state that allows duty fee modification
+    const restrictedStatuses = ['ready_for_pickup', 'delivered'];
+    if (restrictedStatuses.includes(existingPackage.status)) {
+      throw new AppError('Cannot add duty fees to packages that are ready for pickup or delivered', 400);
+    }
+
+    // Validate custom fee type when fee type is "Other"
+    if (data.feeType === 'Other' && (!data.customFeeType || data.customFeeType.trim() === '')) {
+      throw new AppError('Custom fee type is required when fee type is "Other"', 400);
+    }
+
+    // Create the duty fee
+    const dutyFee = await this.dutyFeesRepository.create(data, companyId);
+    if (!dutyFee) {
+      throw new AppError('Failed to create duty fee', 500);
+    }
+
+    return dutyFee as DutyFee;
+  }
+
+  /**
+   * Update a duty fee
+   */
+  async updateDutyFee(id: string, data: UpdateDutyFeeRequest, companyId: string): Promise<DutyFee> {
+    // Check if duty fee exists
+    const existingDutyFee = await this.dutyFeesRepository.findById(id, companyId);
+    if (!existingDutyFee) {
+      throw new AppError('Duty fee not found', 404);
+    }
+
+    // Check if the associated package allows duty fee modification
+    const existingPackage = await this.packagesRepository.findById(existingDutyFee.packageId, companyId);
+    if (!existingPackage) {
+      throw new AppError('Associated package not found', 404);
+    }
+
+    const restrictedStatuses = ['ready_for_pickup', 'delivered'];
+    if (restrictedStatuses.includes(existingPackage.status)) {
+      throw new AppError('Cannot modify duty fees for packages that are ready for pickup or delivered', 400);
+    }
+
+    // Validate custom fee type when fee type is "Other"
+    if (data.feeType === 'Other' && (!data.customFeeType || data.customFeeType.trim() === '')) {
+      throw new AppError('Custom fee type is required when fee type is "Other"', 400);
+    }
+
+    // Update the duty fee
+    const updatedDutyFee = await this.dutyFeesRepository.update(id, data, companyId);
+    if (!updatedDutyFee) {
+      throw new AppError('Failed to update duty fee', 500);
+    }
+
+    return updatedDutyFee as DutyFee;
+  }
+
+  /**
+   * Delete a duty fee
+   */
+  async deleteDutyFee(id: string, companyId: string): Promise<void> {
+    // Check if duty fee exists
+    const existingDutyFee = await this.dutyFeesRepository.findById(id, companyId);
+    if (!existingDutyFee) {
+      throw new AppError('Duty fee not found', 404);
+    }
+
+    // Check if the associated package allows duty fee modification
+    const existingPackage = await this.packagesRepository.findById(existingDutyFee.packageId, companyId);
+    if (!existingPackage) {
+      throw new AppError('Associated package not found', 404);
+    }
+
+    const restrictedStatuses = ['ready_for_pickup', 'delivered'];
+    if (restrictedStatuses.includes(existingPackage.status)) {
+      throw new AppError('Cannot delete duty fees from packages that are ready for pickup or delivered', 400);
+    }
+
+    // Delete the duty fee
+    await this.dutyFeesRepository.delete(id, companyId);
+  }
+
+  /**
+   * Get duty fees grouped by currency for a specific package
+   */
+  async getPackageFeesGroupedByCurrency(packageId: string, companyId: string) {
+    // Verify package exists and belongs to company
+    const packageExists = await this.packagesRepository.findById(packageId, companyId);
+    if (!packageExists) {
+      throw new AppError('Package not found', 404);
+    }
+
+    return this.dutyFeesRepository.getPackageFeesGroupedByCurrency(packageId, companyId);
+  }
+
+  /**
+   * Get total duty fees for a package in a specific currency
+   */
+  async getPackageFeeTotal(packageId: string, currency: 'USD' | 'JMD', companyId: string): Promise<number> {
+    // Verify package exists and belongs to company
+    const packageExists = await this.packagesRepository.findById(packageId, companyId);
+    if (!packageExists) {
+      throw new AppError('Package not found', 404);
+    }
+
+    return this.dutyFeesRepository.getTotalByPackageAndCurrency(packageId, currency, companyId);
+  }
+}

--- a/backend/src/types/duty-fee.ts
+++ b/backend/src/types/duty-fee.ts
@@ -1,0 +1,51 @@
+export interface DutyFee {
+  id: string;
+  companyId: string;
+  packageId: string;
+  feeType: string;
+  customFeeType?: string | null;
+  amount: string | number;
+  currency: 'USD' | 'JMD';
+  description?: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface CreateDutyFeeRequest {
+  packageId: string;
+  feeType: string;
+  customFeeType?: string;
+  amount: number;
+  currency: 'USD' | 'JMD';
+  description?: string;
+}
+
+export interface UpdateDutyFeeRequest {
+  feeType?: string;
+  customFeeType?: string;
+  amount?: number;
+  currency?: 'USD' | 'JMD';
+  description?: string;
+}
+
+export const DUTY_FEE_TYPES = [
+  'Electronics',
+  'Clothing & Footwear', 
+  'Food & Grocery',
+  'Household Appliances',
+  'Furniture',
+  'Construction Materials',
+  'Tools & Machinery',
+  'Cosmetics & Personal',
+  'Medical Equipment',
+  'Agricultural Products',
+  'Pet Supplies',
+  'Books & Education',
+  'Mobile Accessories',
+  'ANIMALS',
+  'SOLAR EQUIPMENT',
+  'WRIST WATCHES',
+  'Other'
+] as const;
+
+export type DutyFeeType = typeof DUTY_FEE_TYPES[number];

--- a/backend/src/utils/currency-utils.ts
+++ b/backend/src/utils/currency-utils.ts
@@ -1,0 +1,60 @@
+interface ExchangeRateSettings {
+  baseCurrency: string;
+  targetCurrency: string;
+  exchangeRate: number;
+  lastUpdated?: string;
+  autoUpdate?: boolean;
+}
+
+/**
+ * Convert amount from one currency to another using exchange rate settings
+ */
+export function convertCurrency(
+  amount: number,
+  fromCurrency: string,
+  toCurrency: string,
+  exchangeRateSettings: ExchangeRateSettings
+): number {
+  // If currencies are the same, no conversion needed
+  if (fromCurrency === toCurrency) {
+    return amount;
+  }
+  
+  const { baseCurrency, targetCurrency, exchangeRate } = exchangeRateSettings;
+  
+  // Convert from base to target currency
+  if (fromCurrency === baseCurrency && toCurrency === targetCurrency) {
+    return amount * exchangeRate;
+  }
+  
+  // Convert from target to base currency
+  if (fromCurrency === targetCurrency && toCurrency === baseCurrency) {
+    return amount / exchangeRate;
+  }
+  
+  // If neither matches the configured pair, return original amount
+  // This handles cases where currencies don't match the configured exchange rate
+  console.warn(`Cannot convert from ${fromCurrency} to ${toCurrency} with exchange rate settings`, exchangeRateSettings);
+  return amount;
+}
+
+/**
+ * Get the display currency for billing (usually the company's base currency)
+ */
+export function getDisplayCurrency(exchangeRateSettings: ExchangeRateSettings): string {
+  return exchangeRateSettings.baseCurrency || 'USD';
+}
+
+/**
+ * Format currency amount for display
+ */
+export function formatCurrency(amount: number, currency: string): string {
+  const formatter = new Intl.NumberFormat('en-US', {
+    style: 'decimal',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+  
+  const symbol = currency === 'JMD' ? 'J$' : '$';
+  return `${symbol}${formatter.format(amount)}`;
+}

--- a/backend/src/validation/duty-fee-schemas.ts
+++ b/backend/src/validation/duty-fee-schemas.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod';
+import { DUTY_FEE_TYPES } from '../types/duty-fee';
+
+export const createDutyFeeSchema = z.object({
+  packageId: z.string().uuid('Package ID must be a valid UUID'),
+  feeType: z.enum(DUTY_FEE_TYPES, {
+    errorMap: () => ({ message: 'Invalid duty fee type' })
+  }),
+  customFeeType: z.string().optional().refine((val) => {
+    // If feeType is 'Other', customFeeType is required
+    return val !== undefined || true; // This will be validated in the controller
+  }),
+  amount: z.coerce.number().positive('Amount must be positive'),
+  currency: z.enum(['USD', 'JMD'], {
+    errorMap: () => ({ message: 'Currency must be USD or JMD' })
+  }).default('USD'),
+  description: z.string().optional()
+});
+
+export const updateDutyFeeSchema = z.object({
+  feeType: z.enum(DUTY_FEE_TYPES).optional(),
+  customFeeType: z.string().optional(),
+  amount: z.coerce.number().positive('Amount must be positive').optional(),
+  currency: z.enum(['USD', 'JMD']).optional(),
+  description: z.string().optional()
+});
+
+export const dutyFeeParamsSchema = z.object({
+  id: z.string().uuid('Duty fee ID must be a valid UUID')
+});
+
+export const packageParamsSchema = z.object({
+  packageId: z.string().uuid('Package ID must be a valid UUID')
+});
+
+export type CreateDutyFeeInput = z.infer<typeof createDutyFeeSchema>;
+export type UpdateDutyFeeInput = z.infer<typeof updateDutyFeeSchema>;
+export type DutyFeeParams = z.infer<typeof dutyFeeParamsSchema>;
+export type PackageParams = z.infer<typeof packageParamsSchema>;

--- a/client/components/duty-fee-modal.tsx
+++ b/client/components/duty-fee-modal.tsx
@@ -1,0 +1,220 @@
+"use client";
+
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { dutyFeeService, DUTY_FEE_TYPES, CreateDutyFeeRequest } from "@/lib/api/dutyFeeService";
+import { useToast } from "@/hooks/use-toast";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+const dutyFeeSchema = z.object({
+  feeType: z.enum(DUTY_FEE_TYPES, {
+    errorMap: () => ({ message: "Please select a valid fee type" })
+  }),
+  customFeeType: z.string().optional(),
+  amount: z.coerce.number().positive("Amount must be positive"),
+  currency: z.enum(['USD', 'JMD'], {
+    errorMap: () => ({ message: "Please select a valid currency" })
+  }),
+  description: z.string().optional(),
+}).refine((data) => {
+  // If feeType is 'Other', customFeeType is required
+  if (data.feeType === 'Other' && (!data.customFeeType || data.customFeeType.trim() === '')) {
+    return false;
+  }
+  return true;
+}, {
+  message: "Custom fee type is required when fee type is 'Other'",
+  path: ["customFeeType"],
+});
+
+type DutyFeeFormValues = z.infer<typeof dutyFeeSchema>;
+
+interface DutyFeeModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  packageId: string;
+  packageStatus: string;
+}
+
+export function DutyFeeModal({ isOpen, onClose, packageId, packageStatus }: DutyFeeModalProps) {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  // Check if package allows duty fee modifications
+  const restrictedStatuses = ['ready_for_pickup', 'delivered'];
+  const canModifyFees = !restrictedStatuses.includes(packageStatus);
+
+  const form = useForm<DutyFeeFormValues>({
+    resolver: zodResolver(dutyFeeSchema),
+    defaultValues: {
+      feeType: 'Electronics',
+      customFeeType: '',
+      amount: 0,
+      currency: 'USD',
+      description: '',
+    },
+  });
+
+  const { register, handleSubmit, formState: { errors }, reset, watch, setValue } = form;
+  const selectedFeeType = watch('feeType');
+
+  const createMutation = useMutation({
+    mutationFn: (data: DutyFeeFormValues) => {
+      const createData: CreateDutyFeeRequest = {
+        packageId,
+        feeType: data.feeType,
+        customFeeType: data.feeType === 'Other' ? data.customFeeType : undefined,
+        amount: data.amount,
+        currency: data.currency,
+        description: data.description || undefined,
+      };
+      return dutyFeeService.createDutyFee(createData);
+    },
+    onSuccess: () => {
+      toast({
+        title: "Success",
+        description: "Duty fee has been added successfully.",
+      });
+      queryClient.invalidateQueries({ queryKey: ['duty-fees', packageId] });
+      queryClient.invalidateQueries({ queryKey: ['package', packageId] });
+      reset();
+      onClose();
+    },
+    onError: (error: any) => {
+      toast({
+        title: "Error",
+        description: error.message || "Failed to add duty fee.",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const onSubmit = (data: DutyFeeFormValues) => {
+    createMutation.mutate(data);
+  };
+
+  const handleClose = () => {
+    reset();
+    onClose();
+  };
+
+  if (!canModifyFees) {
+    return (
+      <Dialog open={isOpen} onOpenChange={handleClose}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Cannot Add Duty Fee</DialogTitle>
+          </DialogHeader>
+          <div className="py-4">
+            <p className="text-sm text-gray-600">
+              Duty fees cannot be added to packages that are ready for pickup or already delivered.
+            </p>
+          </div>
+          <DialogFooter>
+            <Button onClick={handleClose} variant="outline">
+              Close
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Add Duty Fee</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <div>
+            <Label htmlFor="feeType">Fee Type</Label>
+            <select
+              {...register("feeType")}
+              className="w-full mt-1 border border-gray-300 rounded-md px-3 py-2 bg-white hover:border-gray-400 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 transition-colors"
+            >
+              {DUTY_FEE_TYPES.map((type) => (
+                <option key={type} value={type}>
+                  {type}
+                </option>
+              ))}
+            </select>
+            {errors.feeType && (
+              <p className="text-red-600 text-sm mt-1">{errors.feeType.message}</p>
+            )}
+          </div>
+
+          {selectedFeeType === 'Other' && (
+            <div>
+              <Label htmlFor="customFeeType">Custom Fee Type</Label>
+              <Input
+                {...register("customFeeType")}
+                placeholder="Enter custom fee type"
+                className="mt-1"
+              />
+              {errors.customFeeType && (
+                <p className="text-red-600 text-sm mt-1">{errors.customFeeType.message}</p>
+              )}
+            </div>
+          )}
+
+          <div>
+            <Label htmlFor="amount">Amount</Label>
+            <Input
+              {...register("amount")}
+              type="number"
+              step="0.01"
+              min="0"
+              placeholder="0.00"
+              className="mt-1"
+            />
+            {errors.amount && (
+              <p className="text-red-600 text-sm mt-1">{errors.amount.message}</p>
+            )}
+          </div>
+
+          <div>
+            <Label htmlFor="currency">Currency</Label>
+            <select
+              {...register("currency")}
+              className="w-full mt-1 border border-gray-300 rounded-md px-3 py-2 bg-white hover:border-gray-400 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 transition-colors"
+            >
+              <option value="USD">USD</option>
+              <option value="JMD">JMD</option>
+            </select>
+            {errors.currency && (
+              <p className="text-red-600 text-sm mt-1">{errors.currency.message}</p>
+            )}
+          </div>
+
+          <div>
+            <Label htmlFor="description">Description (Optional)</Label>
+            <Input
+              {...register("description")}
+              placeholder="Additional details about this fee"
+              className="mt-1"
+            />
+            {errors.description && (
+              <p className="text-red-600 text-sm mt-1">{errors.description.message}</p>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={handleClose}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={createMutation.isPending}>
+              {createMutation.isPending ? "Adding..." : "Add Duty Fee"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/lib/api/dutyFeeService.ts
+++ b/client/lib/api/dutyFeeService.ts
@@ -1,0 +1,139 @@
+import { apiClient } from './apiClient';
+import { authService } from './authService';
+
+export interface DutyFee {
+  id: string;
+  companyId: string;
+  packageId: string;
+  feeType: string;
+  customFeeType?: string;
+  amount: number;
+  currency: 'USD' | 'JMD';
+  description?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateDutyFeeRequest {
+  packageId: string;
+  feeType: string;
+  customFeeType?: string;
+  amount: number;
+  currency: 'USD' | 'JMD';
+  description?: string;
+}
+
+export interface UpdateDutyFeeRequest {
+  feeType?: string;
+  customFeeType?: string;
+  amount?: number;
+  currency?: 'USD' | 'JMD';
+  description?: string;
+}
+
+export const DUTY_FEE_TYPES = [
+  'Electronics',
+  'Clothing & Footwear', 
+  'Food & Grocery',
+  'Household Appliances',
+  'Furniture',
+  'Construction Materials',
+  'Tools & Machinery',
+  'Cosmetics & Personal',
+  'Medical Equipment',
+  'Agricultural Products',
+  'Pet Supplies',
+  'Books & Education',
+  'Mobile Accessories',
+  'ANIMALS',
+  'SOLAR EQUIPMENT',
+  'WRIST WATCHES',
+  'Other'
+] as const;
+
+export type DutyFeeType = typeof DUTY_FEE_TYPES[number];
+
+class DutyFeeService {
+  private baseUrl = '/companies';
+
+  /**
+   * Helper to get the current company ID
+   */
+  private async getCompanyId(): Promise<string> {
+    const userProfile = await authService.getProfile();
+    
+    if (!userProfile || !userProfile.companyId) {
+      throw new Error('Unable to fetch user company information');
+    }
+    
+    return userProfile.companyId;
+  }
+
+  /**
+   * Get all duty fees for the company
+   */
+  async getAllDutyFees(): Promise<DutyFee[]> {
+    const companyId = await this.getCompanyId();
+    return apiClient.get<DutyFee[]>(`${this.baseUrl}/${companyId}/duty-fees`);
+  }
+
+  /**
+   * Get duty fees for a specific package
+   */
+  async getDutyFeesByPackageId(packageId: string): Promise<DutyFee[]> {
+    const companyId = await this.getCompanyId();
+    return apiClient.get<DutyFee[]>(`${this.baseUrl}/${companyId}/duty-fees/package/${packageId}`);
+  }
+
+  /**
+   * Get duty fees grouped by currency for a package
+   */
+  async getPackageFeesGroupedByCurrency(packageId: string): Promise<any> {
+    const companyId = await this.getCompanyId();
+    return apiClient.get(`${this.baseUrl}/${companyId}/duty-fees/package/${packageId}/grouped`);
+  }
+
+  /**
+   * Get total duty fees for a package in a specific currency
+   */
+  async getPackageFeeTotal(packageId: string, currency: 'USD' | 'JMD'): Promise<{ total: number; currency: string }> {
+    const companyId = await this.getCompanyId();
+    return apiClient.get(`${this.baseUrl}/${companyId}/duty-fees/package/${packageId}/total`, {
+      params: { currency }
+    });
+  }
+
+  /**
+   * Get a specific duty fee by ID
+   */
+  async getDutyFeeById(id: string): Promise<DutyFee> {
+    const companyId = await this.getCompanyId();
+    return apiClient.get<DutyFee>(`${this.baseUrl}/${companyId}/duty-fees/${id}`);
+  }
+
+  /**
+   * Create a new duty fee
+   */
+  async createDutyFee(data: CreateDutyFeeRequest): Promise<DutyFee> {
+    const companyId = await this.getCompanyId();
+    return apiClient.post<DutyFee>(`${this.baseUrl}/${companyId}/duty-fees`, data);
+  }
+
+  /**
+   * Update a duty fee
+   */
+  async updateDutyFee(id: string, data: UpdateDutyFeeRequest): Promise<DutyFee> {
+    const companyId = await this.getCompanyId();
+    return apiClient.put<DutyFee>(`${this.baseUrl}/${companyId}/duty-fees/${id}`, data);
+  }
+
+  /**
+   * Delete a duty fee
+   */
+  async deleteDutyFee(id: string): Promise<void> {
+    const companyId = await this.getCompanyId();
+    return apiClient.delete(`${this.baseUrl}/${companyId}/duty-fees/${id}`);
+  }
+}
+
+export const dutyFeeService = new DutyFeeService();

--- a/client/postcss.config.mjs
+++ b/client/postcss.config.mjs
@@ -2,6 +2,7 @@
 const config = {
   plugins: {
     tailwindcss: {},
+    autoprefixer: {},
   },
 };
 


### PR DESCRIPTION
- Implemented DutyFeesController to handle CRUD operations for duty fees.
- Created DutyFeesService and DutyFeesRepository for business logic and data access.
- Added routes for duty fees in duty-fees-routes.ts.
- Introduced database schema for duty fees, including necessary migrations.
- Developed client-side components and services for managing duty fees.
- Integrated duty fees into package registration and detail views.
- Added validation schemas for creating and updating duty fees.