### PR TITLE
Add invoice cancellation functionality

### DIFF
--- a/client/components/invoices/InvoicePDFRenderer.tsx
+++ b/client/components/invoices/InvoicePDFRenderer.tsx
@@ -33,6 +33,26 @@ const InvoicePDFRenderer: React.FC<InvoicePDFRendererProps> = ({
   currency = 'USD',
   exchangeRateSettings
 }) => {
+  // Validate required props
+  if (!invoice || !user || !company) {
+    console.warn('InvoicePDFRenderer: Missing required props', { 
+      invoice: !!invoice, 
+      user: !!user, 
+      company: !!company 
+    });
+    return (
+      <Button 
+        variant="outline" 
+        size="sm"
+        disabled
+        {...buttonProps}
+      >
+        <Download className="mr-2 h-4 w-4" />
+        Data Missing
+      </Button>
+    );
+  }
+
   // Fallback for direct download without PDFDownloadLink
   const [isGenerating, setIsGenerating] = useState(false);
 
@@ -73,7 +93,7 @@ const InvoicePDFRenderer: React.FC<InvoicePDFRendererProps> = ({
       document={
         <InvoicePDF 
           invoice={invoice}
-          packages={packages}
+          packages={packages || []}
           user={user}
           company={company}
           currency={currency}
@@ -83,6 +103,7 @@ const InvoicePDFRenderer: React.FC<InvoicePDFRendererProps> = ({
     >
       {({ loading, url, error }) => {
         if (error) {
+          console.error('InvoicePDFRenderer: PDF generation error', error);
           return (
             <Button 
               variant="outline" 
@@ -92,7 +113,7 @@ const InvoicePDFRenderer: React.FC<InvoicePDFRendererProps> = ({
               {...buttonProps}
             >
               <Download className="mr-2 h-4 w-4" />
-              {isGenerating ? 'Generating...' : buttonText}
+              {isGenerating ? 'Generating...' : 'PDF Error - Retry'}
             </Button>
           );
         }

--- a/client/lib/api/invoiceService.ts
+++ b/client/lib/api/invoiceService.ts
@@ -177,6 +177,14 @@ class InvoiceService {
     if (options?.notify !== undefined) params.notify = options.notify;
     await apiClient.delete(`${this.baseUrl}/${cId}/invoices/${id}`, { params });
   }
+
+  /**
+   * Cancel an invoice by ID
+   */
+  async cancelInvoice(id: string, companyId?: string): Promise<Invoice> {
+    const cId = companyId || await this.getCompanyId();
+    return apiClient.post<Invoice>(`${this.baseUrl}/${cId}/invoices/${id}/cancel`);
+  }
 }
 
 // Export as singleton


### PR DESCRIPTION
- Implemented the ability to cancel invoices, including un-linking associated packages and deleting invoice items.
- Enhanced the InvoicesService to handle cancellation logic and revert package statuses.
- Updated the client-side to include a cancel invoice dialog and button, with appropriate state management and user feedback.
- Added a new hook for cancelling invoices and ensured proper cache invalidation for related queries.
- Improved the InvoicePDF and InvoicePDFRenderer components to handle missing data gracefully.