### PR TITLE
Patch/manual importing

### DIFF
--- a/backend/src/db/migrations/0027_good_vengeance.sql
+++ b/backend/src/db/migrations/0027_good_vengeance.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "packages" ADD COLUMN "warehouse_receipt" text;
+--> statement-breakpoint
+-- Backfill the warehouse receipt for previously imported rows that only stored it in notes.
+UPDATE "packages"
+SET "warehouse_receipt" = substring("notes" from 'Warehouse Receipt:\s*(HLS-[0-9]+)')
+WHERE "warehouse_receipt" IS NULL
+  AND "notes" LIKE '%Warehouse Receipt:%';

--- a/backend/src/db/migrations/0028_empty_lockheed.sql
+++ b/backend/src/db/migrations/0028_empty_lockheed.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS "packages_company_warehouse_receipt_idx" ON "packages" ("company_id","warehouse_receipt");

--- a/backend/src/db/migrations/meta/0027_snapshot.json
+++ b/backend/src/db/migrations/meta/0027_snapshot.json
@@ -1,0 +1,1690 @@
+{
+  "version": "5",
+  "dialect": "pg",
+  "id": "aec28506-b5cc-4338-b1b0-ce0c8a96be9a",
+  "prevId": "cdf16acf-f06a-49e8-9ff7-ccd902ff339d",
+  "tables": {
+    "audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_logs_company_id_companies_id_fk": {
+          "name": "audit_logs_company_id_companies_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "companies": {
+      "name": "companies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subdomain": {
+          "name": "subdomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "images": {
+          "name": "images",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_info": {
+          "name": "shipping_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locations": {
+          "name": "locations",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bank_info": {
+          "name": "bank_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "companies_subdomain_unique": {
+          "name": "companies_subdomain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "subdomain"
+          ]
+        },
+        "companies_email_unique": {
+          "name": "companies_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    },
+    "company_assets": {
+      "name": "company_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "asset_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "image_data": {
+          "name": "image_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "company_assets_company_id_companies_id_fk": {
+          "name": "company_assets_company_id_companies_id_fk",
+          "tableFrom": "company_assets",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "company_invitations": {
+      "name": "company_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "invitation_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "company_invitations_token_unique": {
+          "name": "company_invitations_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      }
+    },
+    "company_settings": {
+      "name": "company_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_prefix": {
+          "name": "internal_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SPX'"
+        },
+        "notification_settings": {
+          "name": "notification_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "theme_settings": {
+          "name": "theme_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "payment_settings": {
+          "name": "payment_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "integration_settings": {
+          "name": "integration_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "exchange_rate_settings": {
+          "name": "exchange_rate_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"baseCurrency\":\"USD\",\"targetCurrency\":\"JMD\",\"exchangeRate\":158.5,\"lastUpdated\":null,\"autoUpdate\":false}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "company_settings_company_id_companies_id_fk": {
+          "name": "company_settings_company_id_companies_id_fk",
+          "tableFrom": "company_settings",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "company_settings_company_id_unique": {
+          "name": "company_settings_company_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "company_id"
+          ]
+        }
+      }
+    },
+    "duty_fees": {
+      "name": "duty_fees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_type": {
+          "name": "fee_type",
+          "type": "duty_fee_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_fee_type": {
+          "name": "custom_fee_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "duty_fees_company_id_companies_id_fk": {
+          "name": "duty_fees_company_id_companies_id_fk",
+          "tableFrom": "duty_fees",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "duty_fees_package_id_packages_id_fk": {
+          "name": "duty_fees_package_id_packages_id_fk",
+          "tableFrom": "duty_fees",
+          "tableTo": "packages",
+          "columnsFrom": [
+            "package_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "fees": {
+      "name": "fees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_type": {
+          "name": "fee_type",
+          "type": "fee_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calculation_method": {
+          "name": "calculation_method",
+          "type": "calculation_method",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "applies_to": {
+          "name": "applies_to",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fees_company_id_companies_id_fk": {
+          "name": "fees_company_id_companies_id_fk",
+          "tableFrom": "fees",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "invoice_items": {
+      "name": "invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_total": {
+          "name": "line_total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "invoice_item_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoice_items_company_id_companies_id_fk": {
+          "name": "invoice_items_company_id_companies_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_items_package_id_packages_id_fk": {
+          "name": "invoice_items_package_id_packages_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "packages",
+          "columnsFrom": [
+            "package_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "issue_date": {
+          "name": "issue_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "tax_amount": {
+          "name": "tax_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fee_breakdown": {
+          "name": "fee_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoices_company_id_companies_id_fk": {
+          "name": "invoices_company_id_companies_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoices_user_id_users_id_fk": {
+          "name": "invoices_user_id_users_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoices_invoice_number_unique": {
+          "name": "invoices_invoice_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invoice_number"
+          ]
+        }
+      }
+    },
+    "packages": {
+      "name": "packages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pref_id": {
+          "name": "pref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracking_number": {
+          "name": "tracking_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "warehouse_receipt": {
+          "name": "warehouse_receipt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "package_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'received'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "declared_value": {
+          "name": "declared_value",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_info": {
+          "name": "sender_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_date": {
+          "name": "received_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_date": {
+          "name": "processing_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photos": {
+          "name": "photos",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "packages_company_id_companies_id_fk": {
+          "name": "packages_company_id_companies_id_fk",
+          "tableFrom": "packages",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "packages_user_id_users_id_fk": {
+          "name": "packages_user_id_users_id_fk",
+          "tableFrom": "packages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "packages_tracking_number_unique": {
+          "name": "packages_tracking_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tracking_number"
+          ]
+        }
+      }
+    },
+    "payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "payment_method",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "payment_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_date": {
+          "name": "payment_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "payments_company_id_companies_id_fk": {
+          "name": "payments_company_id_companies_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payments_invoice_id_invoices_id_fk": {
+          "name": "payments_invoice_id_invoices_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payments_user_id_users_id_fk": {
+          "name": "payments_user_id_users_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "pre_alerts": {
+      "name": "pre_alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tracking_number": {
+          "name": "tracking_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "courier": {
+          "name": "courier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_weight": {
+          "name": "estimated_weight",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_arrival": {
+          "name": "estimated_arrival",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "pre_alert_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "documents": {
+          "name": "documents",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pre_alerts_company_id_companies_id_fk": {
+          "name": "pre_alerts_company_id_companies_id_fk",
+          "tableFrom": "pre_alerts",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pre_alerts_user_id_users_id_fk": {
+          "name": "pre_alerts_user_id_users_id_fk",
+          "tableFrom": "pre_alerts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pre_alerts_package_id_packages_id_fk": {
+          "name": "pre_alerts_package_id_packages_id_fk",
+          "tableFrom": "pre_alerts",
+          "tableTo": "packages",
+          "columnsFrom": [
+            "package_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pref_id": {
+          "name": "pref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trn": {
+          "name": "trn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'customer'"
+        },
+        "auth0_id": {
+          "name": "auth0_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verification_token": {
+          "name": "verification_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_token_expires": {
+          "name": "verification_token_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_preferences": {
+          "name": "notification_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"email\":true,\"sms\":false,\"push\":false,\"packageUpdates\":{\"email\":true,\"sms\":false,\"push\":false},\"billingUpdates\":{\"email\":true,\"sms\":false,\"push\":false},\"marketingUpdates\":{\"email\":false,\"sms\":false,\"push\":false},\"pickupLocationId\":null}'::jsonb"
+        },
+        "reset_token": {
+          "name": "reset_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_token_expires": {
+          "name": "reset_token_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_company_id_companies_id_fk": {
+          "name": "users_company_id_companies_id_fk",
+          "tableFrom": "users",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_internal_id_unique": {
+          "name": "users_internal_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "internal_id"
+          ]
+        },
+        "users_pref_id_unique": {
+          "name": "users_pref_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pref_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "asset_type": {
+      "name": "asset_type",
+      "values": {
+        "logo": "logo",
+        "banner": "banner",
+        "favicon": "favicon",
+        "small_logo": "small_logo"
+      }
+    },
+    "invitation_status": {
+      "name": "invitation_status",
+      "values": {
+        "pending": "pending",
+        "accepted": "accepted",
+        "expired": "expired",
+        "cancelled": "cancelled"
+      }
+    },
+    "currency": {
+      "name": "currency",
+      "values": {
+        "USD": "USD",
+        "JMD": "JMD"
+      }
+    },
+    "duty_fee_type": {
+      "name": "duty_fee_type",
+      "values": {
+        "Electronics": "Electronics",
+        "Clothing & Footwear": "Clothing & Footwear",
+        "Food & Grocery": "Food & Grocery",
+        "Household Appliances": "Household Appliances",
+        "Furniture": "Furniture",
+        "Construction Materials": "Construction Materials",
+        "Tools & Machinery": "Tools & Machinery",
+        "Cosmetics & Personal": "Cosmetics & Personal",
+        "Medical Equipment": "Medical Equipment",
+        "Agricultural Products": "Agricultural Products",
+        "Pet Supplies": "Pet Supplies",
+        "Books & Education": "Books & Education",
+        "Mobile Accessories": "Mobile Accessories",
+        "ANIMALS": "ANIMALS",
+        "SOLAR EQUIPMENT": "SOLAR EQUIPMENT",
+        "WRIST WATCHES": "WRIST WATCHES",
+        "Other": "Other"
+      }
+    },
+    "calculation_method": {
+      "name": "calculation_method",
+      "values": {
+        "fixed": "fixed",
+        "percentage": "percentage",
+        "per_weight": "per_weight",
+        "per_item": "per_item",
+        "dimensional": "dimensional",
+        "tiered": "tiered",
+        "threshold": "threshold",
+        "timed": "timed"
+      }
+    },
+    "fee_type": {
+      "name": "fee_type",
+      "values": {
+        "tax": "tax",
+        "service": "service",
+        "shipping": "shipping",
+        "handling": "handling",
+        "customs": "customs",
+        "other": "other"
+      }
+    },
+    "invoice_item_type": {
+      "name": "invoice_item_type",
+      "values": {
+        "shipping": "shipping",
+        "handling": "handling",
+        "customs": "customs",
+        "tax": "tax",
+        "duty": "duty",
+        "other": "other"
+      }
+    },
+    "invoice_status": {
+      "name": "invoice_status",
+      "values": {
+        "draft": "draft",
+        "issued": "issued",
+        "paid": "paid",
+        "cancelled": "cancelled",
+        "overdue": "overdue"
+      }
+    },
+    "package_status": {
+      "name": "package_status",
+      "values": {
+        "in_transit": "in_transit",
+        "pre_alert": "pre_alert",
+        "received": "received",
+        "processed": "processed",
+        "ready_for_pickup": "ready_for_pickup",
+        "delivered": "delivered",
+        "returned": "returned"
+      }
+    },
+    "payment_method": {
+      "name": "payment_method",
+      "values": {
+        "credit_card": "credit_card",
+        "bank_transfer": "bank_transfer",
+        "cash": "cash",
+        "check": "check",
+        "online": "online"
+      }
+    },
+    "payment_status": {
+      "name": "payment_status",
+      "values": {
+        "pending": "pending",
+        "completed": "completed",
+        "failed": "failed",
+        "refunded": "refunded"
+      }
+    },
+    "pre_alert_status": {
+      "name": "pre_alert_status",
+      "values": {
+        "pending": "pending",
+        "matched": "matched",
+        "cancelled": "cancelled"
+      }
+    },
+    "user_role": {
+      "name": "user_role",
+      "values": {
+        "customer": "customer",
+        "admin_l1": "admin_l1",
+        "admin_l2": "admin_l2",
+        "super_admin": "super_admin"
+      }
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/backend/src/db/migrations/meta/0028_snapshot.json
+++ b/backend/src/db/migrations/meta/0028_snapshot.json
@@ -1,0 +1,1699 @@
+{
+  "version": "5",
+  "dialect": "pg",
+  "id": "c269bc88-5f49-4169-82b8-da1b89b4d65c",
+  "prevId": "aec28506-b5cc-4338-b1b0-ce0c8a96be9a",
+  "tables": {
+    "audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_logs_company_id_companies_id_fk": {
+          "name": "audit_logs_company_id_companies_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "companies": {
+      "name": "companies",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subdomain": {
+          "name": "subdomain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "images": {
+          "name": "images",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "shipping_info": {
+          "name": "shipping_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locations": {
+          "name": "locations",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bank_info": {
+          "name": "bank_info",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "companies_subdomain_unique": {
+          "name": "companies_subdomain_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "subdomain"
+          ]
+        },
+        "companies_email_unique": {
+          "name": "companies_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    },
+    "company_assets": {
+      "name": "company_assets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "asset_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "image_data": {
+          "name": "image_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "company_assets_company_id_companies_id_fk": {
+          "name": "company_assets_company_id_companies_id_fk",
+          "tableFrom": "company_assets",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "company_invitations": {
+      "name": "company_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "invitation_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "company_invitations_token_unique": {
+          "name": "company_invitations_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      }
+    },
+    "company_settings": {
+      "name": "company_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_prefix": {
+          "name": "internal_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'SPX'"
+        },
+        "notification_settings": {
+          "name": "notification_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "theme_settings": {
+          "name": "theme_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "payment_settings": {
+          "name": "payment_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "integration_settings": {
+          "name": "integration_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "exchange_rate_settings": {
+          "name": "exchange_rate_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"baseCurrency\":\"USD\",\"targetCurrency\":\"JMD\",\"exchangeRate\":158.5,\"lastUpdated\":null,\"autoUpdate\":false}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "company_settings_company_id_companies_id_fk": {
+          "name": "company_settings_company_id_companies_id_fk",
+          "tableFrom": "company_settings",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "company_settings_company_id_unique": {
+          "name": "company_settings_company_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "company_id"
+          ]
+        }
+      }
+    },
+    "duty_fees": {
+      "name": "duty_fees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_type": {
+          "name": "fee_type",
+          "type": "duty_fee_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "custom_fee_type": {
+          "name": "custom_fee_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "duty_fees_company_id_companies_id_fk": {
+          "name": "duty_fees_company_id_companies_id_fk",
+          "tableFrom": "duty_fees",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "duty_fees_package_id_packages_id_fk": {
+          "name": "duty_fees_package_id_packages_id_fk",
+          "tableFrom": "duty_fees",
+          "tableTo": "packages",
+          "columnsFrom": [
+            "package_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "fees": {
+      "name": "fees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fee_type": {
+          "name": "fee_type",
+          "type": "fee_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "calculation_method": {
+          "name": "calculation_method",
+          "type": "calculation_method",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "varchar(3)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'USD'"
+        },
+        "applies_to": {
+          "name": "applies_to",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "fees_company_id_companies_id_fk": {
+          "name": "fees_company_id_companies_id_fk",
+          "tableFrom": "fees",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "invoice_items": {
+      "name": "invoice_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "unit_price": {
+          "name": "unit_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "line_total": {
+          "name": "line_total",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "invoice_item_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoice_items_company_id_companies_id_fk": {
+          "name": "invoice_items_company_id_companies_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_items_invoice_id_invoices_id_fk": {
+          "name": "invoice_items_invoice_id_invoices_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoice_items_package_id_packages_id_fk": {
+          "name": "invoice_items_package_id_packages_id_fk",
+          "tableFrom": "invoice_items",
+          "tableTo": "packages",
+          "columnsFrom": [
+            "package_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "invoices": {
+      "name": "invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "invoice_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "issue_date": {
+          "name": "issue_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "due_date": {
+          "name": "due_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subtotal": {
+          "name": "subtotal",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "tax_amount": {
+          "name": "tax_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "total_amount": {
+          "name": "total_amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fee_breakdown": {
+          "name": "fee_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invoices_company_id_companies_id_fk": {
+          "name": "invoices_company_id_companies_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invoices_user_id_users_id_fk": {
+          "name": "invoices_user_id_users_id_fk",
+          "tableFrom": "invoices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invoices_invoice_number_unique": {
+          "name": "invoices_invoice_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "invoice_number"
+          ]
+        }
+      }
+    },
+    "packages": {
+      "name": "packages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pref_id": {
+          "name": "pref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracking_number": {
+          "name": "tracking_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "warehouse_receipt": {
+          "name": "warehouse_receipt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "package_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'received'"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "declared_value": {
+          "name": "declared_value",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sender_info": {
+          "name": "sender_info",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_date": {
+          "name": "received_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_date": {
+          "name": "processing_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photos": {
+          "name": "photos",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "packages_company_warehouse_receipt_idx": {
+          "name": "packages_company_warehouse_receipt_idx",
+          "columns": [
+            "company_id",
+            "warehouse_receipt"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "packages_company_id_companies_id_fk": {
+          "name": "packages_company_id_companies_id_fk",
+          "tableFrom": "packages",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "packages_user_id_users_id_fk": {
+          "name": "packages_user_id_users_id_fk",
+          "tableFrom": "packages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "packages_tracking_number_unique": {
+          "name": "packages_tracking_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tracking_number"
+          ]
+        }
+      }
+    },
+    "payments": {
+      "name": "payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invoice_id": {
+          "name": "invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "payment_method",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "payment_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_date": {
+          "name": "payment_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "payments_company_id_companies_id_fk": {
+          "name": "payments_company_id_companies_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payments_invoice_id_invoices_id_fk": {
+          "name": "payments_invoice_id_invoices_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "invoices",
+          "columnsFrom": [
+            "invoice_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "payments_user_id_users_id_fk": {
+          "name": "payments_user_id_users_id_fk",
+          "tableFrom": "payments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "pre_alerts": {
+      "name": "pre_alerts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tracking_number": {
+          "name": "tracking_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "courier": {
+          "name": "courier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_weight": {
+          "name": "estimated_weight",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "estimated_arrival": {
+          "name": "estimated_arrival",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "package_id": {
+          "name": "package_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "pre_alert_status",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "documents": {
+          "name": "documents",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pre_alerts_company_id_companies_id_fk": {
+          "name": "pre_alerts_company_id_companies_id_fk",
+          "tableFrom": "pre_alerts",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pre_alerts_user_id_users_id_fk": {
+          "name": "pre_alerts_user_id_users_id_fk",
+          "tableFrom": "pre_alerts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pre_alerts_package_id_packages_id_fk": {
+          "name": "pre_alerts_package_id_packages_id_fk",
+          "tableFrom": "pre_alerts",
+          "tableTo": "packages",
+          "columnsFrom": [
+            "package_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "internal_id": {
+          "name": "internal_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pref_id": {
+          "name": "pref_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trn": {
+          "name": "trn",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'customer'"
+        },
+        "auth0_id": {
+          "name": "auth0_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verification_token": {
+          "name": "verification_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verification_token_expires": {
+          "name": "verification_token_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_preferences": {
+          "name": "notification_preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{\"email\":true,\"sms\":false,\"push\":false,\"packageUpdates\":{\"email\":true,\"sms\":false,\"push\":false},\"billingUpdates\":{\"email\":true,\"sms\":false,\"push\":false},\"marketingUpdates\":{\"email\":false,\"sms\":false,\"push\":false},\"pickupLocationId\":null}'::jsonb"
+        },
+        "reset_token": {
+          "name": "reset_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reset_token_expires": {
+          "name": "reset_token_expires",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_company_id_companies_id_fk": {
+          "name": "users_company_id_companies_id_fk",
+          "tableFrom": "users",
+          "tableTo": "companies",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_internal_id_unique": {
+          "name": "users_internal_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "internal_id"
+          ]
+        },
+        "users_pref_id_unique": {
+          "name": "users_pref_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pref_id"
+          ]
+        },
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      }
+    }
+  },
+  "enums": {
+    "asset_type": {
+      "name": "asset_type",
+      "values": {
+        "logo": "logo",
+        "banner": "banner",
+        "favicon": "favicon",
+        "small_logo": "small_logo"
+      }
+    },
+    "invitation_status": {
+      "name": "invitation_status",
+      "values": {
+        "pending": "pending",
+        "accepted": "accepted",
+        "expired": "expired",
+        "cancelled": "cancelled"
+      }
+    },
+    "currency": {
+      "name": "currency",
+      "values": {
+        "USD": "USD",
+        "JMD": "JMD"
+      }
+    },
+    "duty_fee_type": {
+      "name": "duty_fee_type",
+      "values": {
+        "Electronics": "Electronics",
+        "Clothing & Footwear": "Clothing & Footwear",
+        "Food & Grocery": "Food & Grocery",
+        "Household Appliances": "Household Appliances",
+        "Furniture": "Furniture",
+        "Construction Materials": "Construction Materials",
+        "Tools & Machinery": "Tools & Machinery",
+        "Cosmetics & Personal": "Cosmetics & Personal",
+        "Medical Equipment": "Medical Equipment",
+        "Agricultural Products": "Agricultural Products",
+        "Pet Supplies": "Pet Supplies",
+        "Books & Education": "Books & Education",
+        "Mobile Accessories": "Mobile Accessories",
+        "ANIMALS": "ANIMALS",
+        "SOLAR EQUIPMENT": "SOLAR EQUIPMENT",
+        "WRIST WATCHES": "WRIST WATCHES",
+        "Other": "Other"
+      }
+    },
+    "calculation_method": {
+      "name": "calculation_method",
+      "values": {
+        "fixed": "fixed",
+        "percentage": "percentage",
+        "per_weight": "per_weight",
+        "per_item": "per_item",
+        "dimensional": "dimensional",
+        "tiered": "tiered",
+        "threshold": "threshold",
+        "timed": "timed"
+      }
+    },
+    "fee_type": {
+      "name": "fee_type",
+      "values": {
+        "tax": "tax",
+        "service": "service",
+        "shipping": "shipping",
+        "handling": "handling",
+        "customs": "customs",
+        "other": "other"
+      }
+    },
+    "invoice_item_type": {
+      "name": "invoice_item_type",
+      "values": {
+        "shipping": "shipping",
+        "handling": "handling",
+        "customs": "customs",
+        "tax": "tax",
+        "duty": "duty",
+        "other": "other"
+      }
+    },
+    "invoice_status": {
+      "name": "invoice_status",
+      "values": {
+        "draft": "draft",
+        "issued": "issued",
+        "paid": "paid",
+        "cancelled": "cancelled",
+        "overdue": "overdue"
+      }
+    },
+    "package_status": {
+      "name": "package_status",
+      "values": {
+        "in_transit": "in_transit",
+        "pre_alert": "pre_alert",
+        "received": "received",
+        "processed": "processed",
+        "ready_for_pickup": "ready_for_pickup",
+        "delivered": "delivered",
+        "returned": "returned"
+      }
+    },
+    "payment_method": {
+      "name": "payment_method",
+      "values": {
+        "credit_card": "credit_card",
+        "bank_transfer": "bank_transfer",
+        "cash": "cash",
+        "check": "check",
+        "online": "online"
+      }
+    },
+    "payment_status": {
+      "name": "payment_status",
+      "values": {
+        "pending": "pending",
+        "completed": "completed",
+        "failed": "failed",
+        "refunded": "refunded"
+      }
+    },
+    "pre_alert_status": {
+      "name": "pre_alert_status",
+      "values": {
+        "pending": "pending",
+        "matched": "matched",
+        "cancelled": "cancelled"
+      }
+    },
+    "user_role": {
+      "name": "user_role",
+      "values": {
+        "customer": "customer",
+        "admin_l1": "admin_l1",
+        "admin_l2": "admin_l2",
+        "super_admin": "super_admin"
+      }
+    }
+  },
+  "schemas": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  }
+}

--- a/backend/src/db/migrations/meta/_journal.json
+++ b/backend/src/db/migrations/meta/_journal.json
@@ -190,6 +190,20 @@
       "when": 1753205802445,
       "tag": "0026_elite_stardust",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "5",
+      "when": 1782751477120,
+      "tag": "0027_good_vengeance",
+      "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "5",
+      "when": 1782751516972,
+      "tag": "0028_empty_lockheed",
+      "breakpoints": true
     }
   ]
 }

--- a/backend/src/db/schema/packages.ts
+++ b/backend/src/db/schema/packages.ts
@@ -1,4 +1,4 @@
-import { pgTable, uuid, text, timestamp, jsonb, pgEnum, decimal } from 'drizzle-orm/pg-core';
+import { pgTable, uuid, text, timestamp, jsonb, pgEnum, decimal, index } from 'drizzle-orm/pg-core';
 import { companies } from './companies';
 import { users } from './users';
 
@@ -23,6 +23,7 @@ export const packages = pgTable('packages', {
   }),
   prefId: text('pref_id'),
   trackingNumber: text('tracking_number').notNull().unique(),
+  warehouseReceipt: text('warehouse_receipt'),
   status: packageStatusEnum('status').notNull().default('received'),
   description: text('description'),
   weight: decimal('weight', { precision: 10, scale: 2 }),
@@ -36,4 +37,9 @@ export const packages = pgTable('packages', {
   notes: text('notes'),
   createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
   updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
-}); 
+}, (table) => ({
+  companyWarehouseReceiptIdx: index('packages_company_warehouse_receipt_idx').on(
+    table.companyId,
+    table.warehouseReceipt
+  ),
+})); 

--- a/backend/src/repositories/packages-repository.ts
+++ b/backend/src/repositories/packages-repository.ts
@@ -48,6 +48,24 @@ export class PackagesRepository extends BaseRepository<typeof packages> {
   }
 
   /**
+   * Find a package by warehouse receipt (e.g. HLS-12559) within a company
+   */
+  async findByWarehouseReceipt(warehouseReceipt: string, companyId: string) {
+    const result = await this.db
+      .select()
+      .from(this.table)
+      .where(
+        and(
+          eq(this.table.warehouseReceipt, warehouseReceipt),
+          eq(this.table.companyId, companyId)
+        )
+      )
+      .limit(1);
+
+    return result.length > 0 ? result[0] : null;
+  }
+
+  /**
    * Find packages by user ID within a company with filtering options
    */
   async findByUserId(

--- a/backend/src/services/import-service.ts
+++ b/backend/src/services/import-service.ts
@@ -127,8 +127,19 @@ export class ImportService {
    */
   async packageExists(trackingNumber: string, companyId: string): Promise<boolean> {
     if (!trackingNumber) return false;
-    
+
     const existingPackage = await this.packagesRepository.findByTrackingNumber(trackingNumber, companyId);
+    return !!existingPackage;
+  }
+
+  /**
+   * Check if a package with the given warehouse receipt (e.g. HLS-12559) already exists.
+   * This is the stable per-package identifier used to skip stale records on re-import.
+   */
+  async packageExistsByWarehouseReceipt(warehouseReceipt: string, companyId: string): Promise<boolean> {
+    if (!warehouseReceipt) return false;
+
+    const existingPackage = await this.packagesRepository.findByWarehouseReceipt(warehouseReceipt, companyId);
     return !!existingPackage;
   }
 
@@ -227,24 +238,42 @@ export class ImportService {
           );
         }
 
-        // Use the external (carrier) tracking number. Records without one get a
-        // system-generated internal tracking number marked with an INTERNAL- prefix.
+        // Warehouse receipt (e.g. HLS-12559) is the stable per-package identifier and
+        // the key we dedup on, so stale records are skipped even though the external
+        // tracking number changes between exports.
+        const warehouseReceipt = (record['Warehouse Receipt'] || record.Number || '').trim();
+
+        if (warehouseReceipt) {
+          // Skip records whose warehouse receipt is already in the database
+          const exists = await this.packageExistsByWarehouseReceipt(warehouseReceipt, safeCompanyId);
+          if (exists) {
+            result.skippedCount++;
+            continue; // Skip this stale record and move to the next one
+          }
+        }
+
+        // Use the external (carrier) tracking number as the stored tracking number.
+        // Records without one get a system-generated internal tracking number marked
+        // with an INTERNAL- prefix.
         const externalTracking = (record['External Tracking Number'] || '').trim();
         let trackingNumber: string;
 
         if (externalTracking) {
-          // Skip records whose external tracking number is already in the database
-          const exists = await this.packageExists(externalTracking, safeCompanyId);
-          if (exists) {
-            result.skippedCount++;
-            continue; // Skip this record and move to the next one
+          // Secondary guard (esp. for records with no warehouse receipt): skip if the
+          // external tracking number itself is already present.
+          if (!warehouseReceipt) {
+            const exists = await this.packageExists(externalTracking, safeCompanyId);
+            if (exists) {
+              result.skippedCount++;
+              continue; // Skip this record and move to the next one
+            }
           }
           trackingNumber = externalTracking;
         } else {
           // No external tracking number — generate a unique internal one
           trackingNumber = await generateTrackingId(safeCompanyId, { internal: true });
         }
-        
+
         // Get description - either from Description field or Notes field
         const description = record.Description || record.Notes || '';
         
@@ -269,9 +298,6 @@ export class ImportService {
           }
         }
         
-        // Get warehouse receipt from either format
-        const warehouseReceipt = record['Warehouse Receipt'] || record.Number || '';
-        
         // Get date - try different formats and fields
         const receivedDate = 
           this.parseDate(record['Entry Date']) || 
@@ -293,6 +319,7 @@ export class ImportService {
         // Map CSV fields to package schema
         const packageData: any = {
           trackingNumber,
+          warehouseReceipt: warehouseReceipt || undefined,
           status: this.mapStatus(record.Status),
           description,
           weight,

--- a/backend/src/validation/package-schemas.ts
+++ b/backend/src/validation/package-schemas.ts
@@ -21,6 +21,7 @@ export const createPackageSchema = z.object({
   notes: z.string().optional(),
   tags: z.array(z.string()).optional(),
   prefId: z.string().optional(),
+  warehouseReceipt: z.string().optional(),
 });
 
 // Schema for updating a package

--- a/scripts/cleanup-duplicate-packages.sql
+++ b/scripts/cleanup-duplicate-packages.sql
@@ -1,118 +1,87 @@
 -- ============================================================================
--- One-off cleanup: remove duplicate packages created by the bad Cargo Detail
--- import (the one that re-added stale records under a new External Tracking
--- Number / INTERNAL- key).
+-- One-off cleanup: remove the OLD duplicate packages left behind by the bad
+-- Cargo Detail import, for company f64eec57-424a-4efe-afc8-4b9580acb518.
 --
--- Strategy: match by the Warehouse Receipt (HLS-xxxxx) extracted from `notes`,
--- scoped to the 30 HLS values in the bad CSV. Only HLS values that have MORE
--- THAN ONE package are touched; for those we KEEP the oldest record (the
--- pre-existing original) and DELETE the newer bad-import duplicate(s).
--- Genuinely-new packages (HLS present only once) are left alone.
+-- Background: every affected package now exists twice in the DB --
+--   * the original, keyed by the old internal tracking number (9010-...)
+--   * a bad-import copy, keyed by the External Tracking Number (GFUS.../TBA.../1Z...)
+-- Both copies share the same warehouse receipt (HLS-...), which uniquely
+-- identifies the physical package.
+--
+-- Rule: DELETE the NEW external/INTERNAL copy (tracking_number NOT LIKE '9010-%')
+-- only when another record with the SAME warehouse_receipt and an old 9010-...
+-- tracking number exists. Keeps the original 9010-... record (already linked to
+-- invoices etc.), removes the bad-import duplicate, and never deletes a package
+-- that has no surviving 9010-... sibling.
+--
+-- PREREQUISITE: run the Part A migration first
+--   (cd backend && npm run db:migrate)
+-- so packages.warehouse_receipt is backfilled. Without it, B1-B3 match nothing.
 --
 -- HOW TO RUN:
---   1. Set :company_id to the affected tenant's UUID.
---   2. Run STEP 1 (and the sanity check) and eyeball the rows.
---   3. Only if STEP 1 looks correct, run STEP 2 inside the transaction.
+--   1. Run STEP 1 (overview) and STEP 2 (dry run); eyeball the rows.
+--   2. Only if STEP 2 looks correct, run STEP 3 inside the transaction.
 --
 -- FK behavior (deletes are NOT blocked): duty_fees.package_id is ON DELETE
 -- CASCADE; invoice_items.package_id and pre_alerts.package_id are ON DELETE
--- SET NULL. Bad-import duplicates are brand new, so they typically have no such
--- children, but be aware any attached duty_fees would cascade-delete.
+-- SET NULL. Per the "delete old as-is" decision the surviving external/INTERNAL
+-- records are treated as holding the correct customer/billing data.
 -- ============================================================================
 
--- Provide the affected tenant id, e.g. in psql:
---   \set company_id '00000000-0000-0000-0000-000000000000'
--- or replace :company_id below with a literal '...'::uuid.
-
--- Reusable list of the warehouse receipts from the bad import CSV.
--- (Defined inline in each query below as a VALUES CTE.)
-
 -- ----------------------------------------------------------------------------
--- STEP 1 — DRY RUN: rows that WILL be deleted (newer duplicates; oldest kept)
+-- STEP 1 -- OVERVIEW: warehouse receipts with more than one package (the
+--          duplicate groups that will be collapsed).
 -- ----------------------------------------------------------------------------
-WITH bad_hls(hls) AS (VALUES
-  ('HLS-12650'),('HLS-12651'),('HLS-12649'),('HLS-12648'),('HLS-12559'),
-  ('HLS-12558'),('HLS-12556'),('HLS-12557'),('HLS-12552'),('HLS-12469'),
-  ('HLS-12468'),('HLS-12464'),('HLS-12463'),('HLS-12461'),('HLS-12462'),
-  ('HLS-12387'),('HLS-12388'),('HLS-12348'),('HLS-12347'),('HLS-12346'),
-  ('HLS-12326'),('HLS-12327'),('HLS-12328'),('HLS-12282'),('HLS-12199'),
-  ('HLS-12198'),('HLS-12200'),('HLS-12166'),('HLS-12165'),('HLS-12167')
-),
-ranked AS (
-  SELECT p.id, p.tracking_number, p.created_at,
-         substring(p.notes from 'Warehouse Receipt:\s*(HLS-[0-9]+)') AS hls,
-         row_number() OVER (
-           PARTITION BY substring(p.notes from 'Warehouse Receipt:\s*(HLS-[0-9]+)')
-           ORDER BY p.created_at ASC
-         ) AS rn,
-         count(*) OVER (
-           PARTITION BY substring(p.notes from 'Warehouse Receipt:\s*(HLS-[0-9]+)')
-         ) AS cnt
-  FROM packages p
-  WHERE p.company_id = :company_id
-    AND substring(p.notes from 'Warehouse Receipt:\s*(HLS-[0-9]+)') IN (SELECT hls FROM bad_hls)
-)
-SELECT id, hls, tracking_number, created_at, cnt AS total_for_hls
-FROM ranked
-WHERE cnt > 1 AND rn > 1          -- duplicates to delete (rn = 1, the oldest, is kept)
-ORDER BY hls, created_at;
+SELECT warehouse_receipt,
+       count(*) AS total,
+       array_agg(tracking_number ORDER BY created_at) AS tracking_numbers
+FROM packages
+WHERE company_id = 'f64eec57-424a-4efe-afc8-4b9580acb518'
+  AND warehouse_receipt IS NOT NULL
+GROUP BY warehouse_receipt
+HAVING count(*) > 1
+ORDER BY warehouse_receipt;
 
 -- ----------------------------------------------------------------------------
--- SANITY CHECK — bad-CSV HLS that are singletons (genuinely-new; NOT deleted)
+-- STEP 2 -- DRY RUN: the exact NEW external/INTERNAL rows that WILL be deleted
+--          (an old 9010-... sibling with the same warehouse receipt exists).
 -- ----------------------------------------------------------------------------
-WITH bad_hls(hls) AS (VALUES
-  ('HLS-12650'),('HLS-12651'),('HLS-12649'),('HLS-12648'),('HLS-12559'),
-  ('HLS-12558'),('HLS-12556'),('HLS-12557'),('HLS-12552'),('HLS-12469'),
-  ('HLS-12468'),('HLS-12464'),('HLS-12463'),('HLS-12461'),('HLS-12462'),
-  ('HLS-12387'),('HLS-12388'),('HLS-12348'),('HLS-12347'),('HLS-12346'),
-  ('HLS-12326'),('HLS-12327'),('HLS-12328'),('HLS-12282'),('HLS-12199'),
-  ('HLS-12198'),('HLS-12200'),('HLS-12166'),('HLS-12165'),('HLS-12167')
-),
-ranked AS (
-  SELECT substring(p.notes from 'Warehouse Receipt:\s*(HLS-[0-9]+)') AS hls,
-         count(*) OVER (
-           PARTITION BY substring(p.notes from 'Warehouse Receipt:\s*(HLS-[0-9]+)')
-         ) AS cnt,
-         p.id
-  FROM packages p
-  WHERE p.company_id = :company_id
-    AND substring(p.notes from 'Warehouse Receipt:\s*(HLS-[0-9]+)') IN (SELECT hls FROM bad_hls)
-)
-SELECT DISTINCT hls, cnt AS total_for_hls
-FROM ranked
-WHERE cnt = 1
-ORDER BY hls;
+SELECT p.id,
+       p.tracking_number,
+       p.warehouse_receipt,
+       p.user_id,
+       p.created_at
+FROM packages p
+WHERE p.company_id = 'f64eec57-424a-4efe-afc8-4b9580acb518'
+  AND p.tracking_number NOT LIKE '9010-%'
+  AND p.warehouse_receipt IS NOT NULL
+  AND EXISTS (
+    SELECT 1 FROM packages e
+    WHERE e.company_id = p.company_id
+      AND e.warehouse_receipt = p.warehouse_receipt
+      AND e.id <> p.id
+      AND e.tracking_number LIKE '9010-%'
+  )
+ORDER BY p.warehouse_receipt;
 
 -- ----------------------------------------------------------------------------
--- STEP 2 — DELETE (run only after STEP 1 looks correct).
+-- STEP 3 -- DELETE (run only after STEP 2 looks correct).
 -- Wrapped in a transaction so you can verify the row count before COMMIT.
 -- ----------------------------------------------------------------------------
 BEGIN;
 
-WITH bad_hls(hls) AS (VALUES
-  ('HLS-12650'),('HLS-12651'),('HLS-12649'),('HLS-12648'),('HLS-12559'),
-  ('HLS-12558'),('HLS-12556'),('HLS-12557'),('HLS-12552'),('HLS-12469'),
-  ('HLS-12468'),('HLS-12464'),('HLS-12463'),('HLS-12461'),('HLS-12462'),
-  ('HLS-12387'),('HLS-12388'),('HLS-12348'),('HLS-12347'),('HLS-12346'),
-  ('HLS-12326'),('HLS-12327'),('HLS-12328'),('HLS-12282'),('HLS-12199'),
-  ('HLS-12198'),('HLS-12200'),('HLS-12166'),('HLS-12165'),('HLS-12167')
-),
-ranked AS (
-  SELECT p.id,
-         row_number() OVER (
-           PARTITION BY substring(p.notes from 'Warehouse Receipt:\s*(HLS-[0-9]+)')
-           ORDER BY p.created_at ASC
-         ) AS rn,
-         count(*) OVER (
-           PARTITION BY substring(p.notes from 'Warehouse Receipt:\s*(HLS-[0-9]+)')
-         ) AS cnt
-  FROM packages p
-  WHERE p.company_id = :company_id
-    AND substring(p.notes from 'Warehouse Receipt:\s*(HLS-[0-9]+)') IN (SELECT hls FROM bad_hls)
-)
-DELETE FROM packages
-WHERE id IN (SELECT id FROM ranked WHERE cnt > 1 AND rn > 1);
+DELETE FROM packages p
+WHERE p.company_id = 'f64eec57-424a-4efe-afc8-4b9580acb518'
+  AND p.tracking_number NOT LIKE '9010-%'
+  AND p.warehouse_receipt IS NOT NULL
+  AND EXISTS (
+    SELECT 1 FROM packages e
+    WHERE e.company_id = p.company_id
+      AND e.warehouse_receipt = p.warehouse_receipt
+      AND e.id <> p.id
+      AND e.tracking_number LIKE '9010-%'
+  );
 
--- Verify the deleted count matches STEP 1, then:
---   COMMIT;   -- to apply
---   ROLLBACK; -- to undo if anything looks off
+-- Verify the deleted count matches STEP 2, then run one of:
+COMMIT;     -- apply the deletion
+-- ROLLBACK; -- undo if anything looks off

--- a/scripts/cleanup-duplicate-packages.sql
+++ b/scripts/cleanup-duplicate-packages.sql
@@ -1,0 +1,118 @@
+-- ============================================================================
+-- One-off cleanup: remove duplicate packages created by the bad Cargo Detail
+-- import (the one that re-added stale records under a new External Tracking
+-- Number / INTERNAL- key).
+--
+-- Strategy: match by the Warehouse Receipt (HLS-xxxxx) extracted from `notes`,
+-- scoped to the 30 HLS values in the bad CSV. Only HLS values that have MORE
+-- THAN ONE package are touched; for those we KEEP the oldest record (the
+-- pre-existing original) and DELETE the newer bad-import duplicate(s).
+-- Genuinely-new packages (HLS present only once) are left alone.
+--
+-- HOW TO RUN:
+--   1. Set :company_id to the affected tenant's UUID.
+--   2. Run STEP 1 (and the sanity check) and eyeball the rows.
+--   3. Only if STEP 1 looks correct, run STEP 2 inside the transaction.
+--
+-- FK behavior (deletes are NOT blocked): duty_fees.package_id is ON DELETE
+-- CASCADE; invoice_items.package_id and pre_alerts.package_id are ON DELETE
+-- SET NULL. Bad-import duplicates are brand new, so they typically have no such
+-- children, but be aware any attached duty_fees would cascade-delete.
+-- ============================================================================
+
+-- Provide the affected tenant id, e.g. in psql:
+--   \set company_id '00000000-0000-0000-0000-000000000000'
+-- or replace :company_id below with a literal '...'::uuid.
+
+-- Reusable list of the warehouse receipts from the bad import CSV.
+-- (Defined inline in each query below as a VALUES CTE.)
+
+-- ----------------------------------------------------------------------------
+-- STEP 1 — DRY RUN: rows that WILL be deleted (newer duplicates; oldest kept)
+-- ----------------------------------------------------------------------------
+WITH bad_hls(hls) AS (VALUES
+  ('HLS-12650'),('HLS-12651'),('HLS-12649'),('HLS-12648'),('HLS-12559'),
+  ('HLS-12558'),('HLS-12556'),('HLS-12557'),('HLS-12552'),('HLS-12469'),
+  ('HLS-12468'),('HLS-12464'),('HLS-12463'),('HLS-12461'),('HLS-12462'),
+  ('HLS-12387'),('HLS-12388'),('HLS-12348'),('HLS-12347'),('HLS-12346'),
+  ('HLS-12326'),('HLS-12327'),('HLS-12328'),('HLS-12282'),('HLS-12199'),
+  ('HLS-12198'),('HLS-12200'),('HLS-12166'),('HLS-12165'),('HLS-12167')
+),
+ranked AS (
+  SELECT p.id, p.tracking_number, p.created_at,
+         substring(p.notes from 'Warehouse Receipt:\s*(HLS-[0-9]+)') AS hls,
+         row_number() OVER (
+           PARTITION BY substring(p.notes from 'Warehouse Receipt:\s*(HLS-[0-9]+)')
+           ORDER BY p.created_at ASC
+         ) AS rn,
+         count(*) OVER (
+           PARTITION BY substring(p.notes from 'Warehouse Receipt:\s*(HLS-[0-9]+)')
+         ) AS cnt
+  FROM packages p
+  WHERE p.company_id = :company_id
+    AND substring(p.notes from 'Warehouse Receipt:\s*(HLS-[0-9]+)') IN (SELECT hls FROM bad_hls)
+)
+SELECT id, hls, tracking_number, created_at, cnt AS total_for_hls
+FROM ranked
+WHERE cnt > 1 AND rn > 1          -- duplicates to delete (rn = 1, the oldest, is kept)
+ORDER BY hls, created_at;
+
+-- ----------------------------------------------------------------------------
+-- SANITY CHECK — bad-CSV HLS that are singletons (genuinely-new; NOT deleted)
+-- ----------------------------------------------------------------------------
+WITH bad_hls(hls) AS (VALUES
+  ('HLS-12650'),('HLS-12651'),('HLS-12649'),('HLS-12648'),('HLS-12559'),
+  ('HLS-12558'),('HLS-12556'),('HLS-12557'),('HLS-12552'),('HLS-12469'),
+  ('HLS-12468'),('HLS-12464'),('HLS-12463'),('HLS-12461'),('HLS-12462'),
+  ('HLS-12387'),('HLS-12388'),('HLS-12348'),('HLS-12347'),('HLS-12346'),
+  ('HLS-12326'),('HLS-12327'),('HLS-12328'),('HLS-12282'),('HLS-12199'),
+  ('HLS-12198'),('HLS-12200'),('HLS-12166'),('HLS-12165'),('HLS-12167')
+),
+ranked AS (
+  SELECT substring(p.notes from 'Warehouse Receipt:\s*(HLS-[0-9]+)') AS hls,
+         count(*) OVER (
+           PARTITION BY substring(p.notes from 'Warehouse Receipt:\s*(HLS-[0-9]+)')
+         ) AS cnt,
+         p.id
+  FROM packages p
+  WHERE p.company_id = :company_id
+    AND substring(p.notes from 'Warehouse Receipt:\s*(HLS-[0-9]+)') IN (SELECT hls FROM bad_hls)
+)
+SELECT DISTINCT hls, cnt AS total_for_hls
+FROM ranked
+WHERE cnt = 1
+ORDER BY hls;
+
+-- ----------------------------------------------------------------------------
+-- STEP 2 — DELETE (run only after STEP 1 looks correct).
+-- Wrapped in a transaction so you can verify the row count before COMMIT.
+-- ----------------------------------------------------------------------------
+BEGIN;
+
+WITH bad_hls(hls) AS (VALUES
+  ('HLS-12650'),('HLS-12651'),('HLS-12649'),('HLS-12648'),('HLS-12559'),
+  ('HLS-12558'),('HLS-12556'),('HLS-12557'),('HLS-12552'),('HLS-12469'),
+  ('HLS-12468'),('HLS-12464'),('HLS-12463'),('HLS-12461'),('HLS-12462'),
+  ('HLS-12387'),('HLS-12388'),('HLS-12348'),('HLS-12347'),('HLS-12346'),
+  ('HLS-12326'),('HLS-12327'),('HLS-12328'),('HLS-12282'),('HLS-12199'),
+  ('HLS-12198'),('HLS-12200'),('HLS-12166'),('HLS-12165'),('HLS-12167')
+),
+ranked AS (
+  SELECT p.id,
+         row_number() OVER (
+           PARTITION BY substring(p.notes from 'Warehouse Receipt:\s*(HLS-[0-9]+)')
+           ORDER BY p.created_at ASC
+         ) AS rn,
+         count(*) OVER (
+           PARTITION BY substring(p.notes from 'Warehouse Receipt:\s*(HLS-[0-9]+)')
+         ) AS cnt
+  FROM packages p
+  WHERE p.company_id = :company_id
+    AND substring(p.notes from 'Warehouse Receipt:\s*(HLS-[0-9]+)') IN (SELECT hls FROM bad_hls)
+)
+DELETE FROM packages
+WHERE id IN (SELECT id FROM ranked WHERE cnt > 1 AND rn > 1);
+
+-- Verify the deleted count matches STEP 1, then:
+--   COMMIT;   -- to apply
+--   ROLLBACK; -- to undo if anything looks off


### PR DESCRIPTION
fixed issue associated with duplicate packages


import-service: added defense to avoid packages that are already apart of the db to be skipped even if it fails the external tracking number check

clean-up-script: added script used for manually cleaning up duplicated packages.